### PR TITLE
New mod: Bad luck protection for gifts

### DIFF
--- a/.run/Publish LobotomyCorporationMods.BadLuckProtectionForGifts to folder.run.xml
+++ b/.run/Publish LobotomyCorporationMods.BadLuckProtectionForGifts to folder.run.xml
@@ -1,0 +1,14 @@
+﻿<component name="ProjectRunConfigurationManager">
+    <configuration default="true" type="DotNetFolderPublish" factoryName="Publish to folder">
+        <riderPublish runtime="win-x86" self_contained="true"
+                      target_folder="$PROJECT_DIR$/../../BadLuckProtectionForGifts" target_framework="net35"
+                      uuid_high="1861080780333796428" uuid_low="-6392915720112860289"/>
+        <method v="2"/>
+    </configuration>
+    <configuration default="false" name="Publish LobotomyCorporationMods.BadLuckProtectionForGifts to folder"
+                   type="DotNetFolderPublish" factoryName="Publish to folder">
+        <riderPublish runtime="win-x86" target_folder="$PROJECT_DIR$/../../BadLuckProtectionForGifts"
+                      target_framework="net35" uuid_high="1861080780333796428" uuid_low="-6392915720112860289"/>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Agent.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Agent.cs
@@ -1,0 +1,14 @@
+﻿namespace LobotomyCorporationMods.BadLuckProtectionForGifts
+{
+    internal sealed class Agent
+    {
+        public Agent(long id)
+        {
+            Id = id;
+            WorkCount = 0f;
+        }
+
+        public long Id { get; }
+        public float WorkCount { get; set; }
+    }
+}

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
@@ -88,6 +88,8 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         ///     gift by '^', and agent id and work count are separated by ';'. A gift can have multiple agents and we don't
         ///     duplicate the gift names.
         ///     Example: (gift1)^(agent1);(workcount1)^(agent2);(workcount2)|(gift2)^(agent1);(workcount2)
+        ///     I would have preferred to use json, but the Unity json support is very minimal and does not support nested
+        ///     objects, so I had to make my own format.
         /// </summary>
         /// <returns></returns>
         public override string ToString()

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 
 namespace LobotomyCorporationMods.BadLuckProtectionForGifts
@@ -19,7 +21,14 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             var gift = Gifts.FirstOrDefault(g => g.Name.Equals(giftName));
             if (gift != null)
             {
-                return gift.Agents.FirstOrDefault(a => a.Id.Equals(agentId));
+                var agent = gift.Agents.FirstOrDefault(a => a.Id.Equals(agentId));
+                if (agent != null)
+                {
+                    return agent;
+                }
+
+                gift.Agents.Add(new Agent(agentId));
+                return gift.Agents.Find(a => a.Id == agentId);
             }
 
             // Gift not found, start tracking the gift
@@ -47,6 +56,27 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             {
                 agent.WorkCount += numberOfTimes;
             }
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            for (var i = 0; i < Gifts.Count; i++)
+            {
+                var gift = Gifts[i];
+                if (i > 0)
+                {
+                    builder.Append('|');
+                }
+
+                builder.Append(gift.Name);
+                foreach (var agent in gift.Agents)
+                {
+                    builder.Append("^" + agent.Id + ";" + agent.WorkCount.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace LobotomyCorporationMods.BadLuckProtectionForGifts
+{
+    public sealed class AgentWorkTracker
+    {
+        public AgentWorkTracker()
+        {
+            Gifts = new List<Gift>();
+        }
+
+        private List<Gift> Gifts { get; }
+
+        [CanBeNull]
+        private Agent GetAgent(string giftName, long agentId)
+        {
+            var gift = Gifts.FirstOrDefault(g => g.Name.Equals(giftName));
+            if (gift != null)
+            {
+                return gift.Agents.FirstOrDefault(a => a.Id.Equals(agentId));
+            }
+
+            // Gift not found, start tracking the gift
+            Gifts.Add(new Gift(giftName));
+            gift = Gifts.Find(g => g.Name.Equals(giftName));
+            gift.Agents.Add(new Agent(agentId));
+            return gift.Agents.Find(a => a.Id == agentId);
+        }
+
+        public float GetAgentWorkCount(string giftName, long agentId)
+        {
+            var agent = GetAgent(giftName, agentId);
+            if (agent == null)
+            {
+                return 0;
+            }
+
+            return agent.WorkCount;
+        }
+
+        public void IncrementAgentWorkCount(string giftName, long agentId, float numberOfTimes = 1f)
+        {
+            var agent = GetAgent(giftName, agentId);
+            if (agent != null)
+            {
+                agent.WorkCount += numberOfTimes;
+            }
+        }
+    }
+}

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/AgentWorkTracker.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
+// ReSharper disable CommentTypo
 namespace LobotomyCorporationMods.BadLuckProtectionForGifts
 {
     public sealed class AgentWorkTracker
@@ -14,6 +15,30 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         }
 
         private List<Gift> Gifts { get; }
+
+        /// <summary>
+        ///     Loads the tracker data from our custom text file.
+        /// </summary>
+        /// <param name="trackerData">The contents of our text file.</param>
+        /// <returns>Loaded AgentWorkTracker object.</returns>
+        [NotNull]
+        public static AgentWorkTracker FromString([NotNull] string trackerData)
+        {
+            var tracker = new AgentWorkTracker();
+            var gifts = trackerData.Split('|');
+            foreach (var gift in gifts)
+            {
+                var giftData = gift.Split('^');
+                var giftName = giftData[0];
+                for (var i = 1; i < giftData.Length; i++)
+                {
+                    var agentData = giftData[i].Split(';');
+                    tracker.IncrementAgentWorkCount(giftName, long.Parse(agentData[0]), float.Parse(agentData[1]));
+                }
+            }
+
+            return tracker;
+        }
 
         [CanBeNull]
         private Agent GetAgent(string giftName, long agentId)
@@ -58,6 +83,13 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             }
         }
 
+        /// <summary>
+        ///     Converts the AgentWorkTracker object to a custom string format. The format delimits gifts by '|', agents for each
+        ///     gift by '^', and agent id and work count are separated by ';'. A gift can have multiple agents and we don't
+        ///     duplicate the gift names.
+        ///     Example: (gift1)^(agent1);(workcount1)^(agent2);(workcount2)|(gift2)^(agent1);(workcount2)
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
             var builder = new StringBuilder();

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Gift.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Gift.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace LobotomyCorporationMods.BadLuckProtectionForGifts
+{
+    internal sealed class Gift
+    {
+        public Gift(string giftName)
+        {
+            Name = giftName;
+            Agents = new List<Agent>();
+        }
+
+        public string Name { get; }
+        public List<Agent> Agents { get; }
+    }
+}

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Gift.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Gift.cs
@@ -4,13 +4,13 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
 {
     internal sealed class Gift
     {
-        public Gift(string giftName)
+        internal Gift(string giftName)
         {
-            Name = giftName;
             Agents = new List<Agent>();
+            Name = giftName;
         }
 
-        public string Name { get; }
-        public List<Agent> Agents { get; }
+        internal List<Agent> Agents { get; }
+        internal string Name { get; }
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -14,16 +14,16 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
     {
         public static AgentWorkTracker AgentWorkTracker;
         public static IFile File;
-        private static string JsonFile;
         private static string LogFile;
+        private static string TrackerFile;
 
         public Harmony_Patch()
         {
             File = new File();
             var dataPath = Application.dataPath + @"/BaseMods/BadLuckProtectionForGifts/";
-            JsonFile = dataPath + "BadLuckProtectionForGifts.json";
+            TrackerFile = dataPath + "BadLuckProtectionForGifts.json";
             LogFile = dataPath + "BadLuckProtectionForGifts_Log.txt";
-            AgentWorkTracker = File.ReadFromJson(JsonFile);
+            //AgentWorkTracker = File.ReadFromJson(JsonFile);
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
@@ -51,7 +51,7 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         public static void CallNewgame([NotNull] AlterTitleController __instance)
         {
             AgentWorkTracker = new AgentWorkTracker();
-            WriteToJson(File);
+            SaveTracker(File);
         }
 
         /// <summary>
@@ -66,26 +66,7 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             var giftName = equipmentMakeInfo.equipTypeInfo.Name;
             var agentId = __instance.agent.instanceId;
             AgentWorkTracker.IncrementAgentWorkCount(giftName, agentId);
-            WriteToJson(File);
-        }
-
-        /// <summary>
-        ///     Writes the AgentWorkTracker to a json file.
-        /// </summary>
-        /// <param name="file">The file interface.</param>
-        private static void WriteToJson([NotNull] IFile file)
-        {
-            file.WriteToJson(JsonFile, AgentWorkTracker);
-        }
-
-        /// <summary>
-        ///     Writes to a log file.
-        /// </summary>
-        /// <param name="file">The file interface.</param>
-        /// <param name="message">The message to log.</param>
-        private static void WriteToLog([NotNull] IFile file, string message)
-        {
-            file.WriteAllText(LogFile, message);
+            SaveTracker(File);
         }
 
         /// <summary>
@@ -106,6 +87,25 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             {
                 __result = 1f;
             }
+        }
+
+        /// <summary>
+        ///     Writes the AgentWorkTracker to a json file.
+        /// </summary>
+        /// <param name="file">The file interface.</param>
+        private static void SaveTracker([NotNull] IFile file)
+        {
+            file.WriteAllText(TrackerFile, AgentWorkTracker.ToString());
+        }
+
+        /// <summary>
+        ///     Writes to a log file.
+        /// </summary>
+        /// <param name="file">The file interface.</param>
+        /// <param name="message">The message to log.</param>
+        private static void WriteToLog([NotNull] IFile file, string message)
+        {
+            file.WriteAllText(LogFile, message);
         }
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -25,7 +25,10 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
-                var harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb"));
+                var harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("CallNewGame"));
+                harmonyInstance.Patch(typeof(AlterTitleController).GetMethod("CallNewGame", AccessTools.all), null,
+                    harmonyMethod);
+                harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb"));
                 harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
                     harmonyMethod);
                 harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("FinishWorkSuccessfully"));
@@ -37,6 +40,16 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
                 WriteToLog(File, ex.Message + Environment.NewLine + ex.StackTrace);
                 throw;
             }
+        }
+
+        /// <summary>
+        ///     Runs after the original CallNewGame method does to reset our agent work when the player starts a new game.
+        /// </summary>
+        /// <param name="__instance">The AlterTitleController event that indicates we're starting a new game.</param>
+        public static void CallNewGame([NotNull] AlterTitleController __instance)
+        {
+            AgentWorkTracker = new AgentWorkTracker();
+            WriteToJson(File);
         }
 
         /// <summary>

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -30,12 +30,14 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
                 var harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("CallNewgame"));
                 harmonyInstance.Patch(typeof(AlterTitleController).GetMethod("CallNewgame", AccessTools.all), null,
                     harmonyMethod);
-                harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb"));
-                harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
+                harmonyInstance.Patch(typeof(NewTitleScript).GetMethod("ClickAfterNewGame", AccessTools.all), null,
                     harmonyMethod);
                 harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("FinishWorkSuccessfully"));
                 harmonyInstance.Patch(typeof(UseSkill).GetMethod("FinishWorkSuccessfully", AccessTools.all),
                     harmonyMethod, null);
+                harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb"));
+                harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
+                    harmonyMethod);
             }
             catch (Exception ex)
             {

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -42,8 +42,15 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
                 probabilityBonus += __instance.prob;
             }
 
-            probabilityBonus += NumberOfTimesWorkedByAgent[1] / 100;
+            probabilityBonus += NumberOfTimesWorkedByAgent[1] / 100f;
             __result = __instance.prob + probabilityBonus;
+
+            // Prevent potential overflow issues
+            if (__result > 1f)
+            {
+                __result = 1f;
+            }
+
             return false;
         }
     }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -5,6 +5,8 @@ using LobotomyCorporationMods.BadLuckProtectionForGifts.Implementations;
 using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
 using UnityEngine;
 
+// ReSharper disable CommentTypo
+// ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 namespace LobotomyCorporationMods.BadLuckProtectionForGifts
 {
@@ -25,8 +27,8 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
-                var harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("CallNewGame"));
-                harmonyInstance.Patch(typeof(AlterTitleController).GetMethod("CallNewGame", AccessTools.all), null,
+                var harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("CallNewgame"));
+                harmonyInstance.Patch(typeof(AlterTitleController).GetMethod("CallNewgame", AccessTools.all), null,
                     harmonyMethod);
                 harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb"));
                 harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
@@ -43,10 +45,10 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         }
 
         /// <summary>
-        ///     Runs after the original CallNewGame method does to reset our agent work when the player starts a new game.
+        ///     Runs after the original CallNewgame method does to reset our agent work when the player starts a new game.
         /// </summary>
         /// <param name="__instance">The AlterTitleController event that indicates we're starting a new game.</param>
-        public static void CallNewGame([NotNull] AlterTitleController __instance)
+        public static void CallNewgame([NotNull] AlterTitleController __instance)
         {
             AgentWorkTracker = new AgentWorkTracker();
             WriteToJson(File);

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -94,7 +94,7 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         /// <param name="__instance">The gift being returned from the creature.</param>
         /// <param name="__result">The probability of getting the gift.</param>
         /// <returns>Always returns false so that we skip the original method entirely.</returns>
-        public static bool GetProb([NotNull] CreatureEquipmentMakeInfo __instance, ref float __result)
+        public static void GetProb([NotNull] CreatureEquipmentMakeInfo __instance, ref float __result)
         {
             var giftName = __instance.equipTypeInfo.Name;
             const long agentId = 1;
@@ -106,8 +106,6 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             {
                 __result = 1f;
             }
-
-            return false;
         }
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Harmony;
+using JetBrains.Annotations;
 using UnityEngine;
 
 // ReSharper disable InconsistentNaming
@@ -13,12 +14,28 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
+                harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all),
+                    new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb")), null);
             }
             catch (Exception ex)
             {
                 File.WriteAllText(Application.dataPath + "/BaseMods/BadLuckProtectionForGifts_Log.txt",
                     ex.Message + Environment.NewLine + ex.StackTrace);
             }
+        }
+
+        /// <summary>
+        ///     Overwrites GetProb with our own logic and result. Original method does not have any side effects.
+        /// </summary>
+        /// <param name="__instance">The gift being returned from the creature.</param>
+        /// <param name="__result">The probability of getting the gift.</param>
+        /// <returns>Always returns false so that we skip the original method entirely.</returns>
+        public static bool GetProb([NotNull] CreatureEquipmentMakeInfo __instance, out float __result)
+        {
+            __result = ResearchDataModel.instance.IsUpgradedAbility("add_efo_gift_prob")
+                ? __instance.prob + __instance.prob
+                : __instance.prob;
+            return false;
         }
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -21,9 +21,9 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         {
             File = new File();
             var dataPath = Application.dataPath + @"/BaseMods/BadLuckProtectionForGifts/";
-            TrackerFile = dataPath + "BadLuckProtectionForGifts.json";
+            TrackerFile = dataPath + "BadLuckProtectionForGifts.dat";
             LogFile = dataPath + "BadLuckProtectionForGifts_Log.txt";
-            //AgentWorkTracker = File.ReadFromJson(JsonFile);
+            AgentWorkTracker = AgentWorkTracker.FromString(File.ReadAllText(TrackerFile));
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
@@ -90,7 +90,7 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         }
 
         /// <summary>
-        ///     Writes the AgentWorkTracker to a json file.
+        ///     Writes the AgentWorkTracker to a text file.
         /// </summary>
         /// <param name="file">The file interface.</param>
         private static void SaveTracker([NotNull] IFile file)

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Harmony;
 using JetBrains.Annotations;
@@ -7,10 +8,13 @@ using UnityEngine;
 // ReSharper disable InconsistentNaming
 namespace LobotomyCorporationMods.BadLuckProtectionForGifts
 {
-    public class Harmony_Patch
+    public sealed class Harmony_Patch
     {
+        public static Dictionary<long, float> NumberOfTimesWorkedByAgent;
+
         public Harmony_Patch()
         {
+            NumberOfTimesWorkedByAgent = new Dictionary<long, float>();
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
@@ -32,9 +36,14 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         /// <returns>Always returns false so that we skip the original method entirely.</returns>
         public static bool GetProb([NotNull] CreatureEquipmentMakeInfo __instance, out float __result)
         {
-            __result = ResearchDataModel.instance.IsUpgradedAbility("add_efo_gift_prob")
-                ? __instance.prob + __instance.prob
-                : __instance.prob;
+            var probabilityBonus = 0f;
+            if (ResearchDataModel.instance.IsUpgradedAbility("add_efo_gift_prob"))
+            {
+                probabilityBonus += __instance.prob;
+            }
+
+            probabilityBonus += NumberOfTimesWorkedByAgent[1] / 100;
+            __result = __instance.prob + probabilityBonus;
             return false;
         }
     }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -18,8 +18,8 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
-                harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all),
-                    new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb")), null);
+                harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
+                    new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb")));
             }
             catch (Exception ex)
             {
@@ -29,21 +29,15 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         }
 
         /// <summary>
-        ///     Overwrites GetProb with our own logic and result. Original method does not have any side effects.
+        ///     Runs after the original GetProb method finishes to add our own probability bonus.
         /// </summary>
         /// <param name="__instance">The gift being returned from the creature.</param>
         /// <param name="__result">The probability of getting the gift.</param>
         /// <returns>Always returns false so that we skip the original method entirely.</returns>
-        public static bool GetProb([NotNull] CreatureEquipmentMakeInfo __instance, out float __result)
+        public static bool GetProb([NotNull] CreatureEquipmentMakeInfo __instance, ref float __result)
         {
-            var probabilityBonus = 0f;
-            if (ResearchDataModel.instance.IsUpgradedAbility("add_efo_gift_prob"))
-            {
-                probabilityBonus += __instance.prob;
-            }
-
-            probabilityBonus += NumberOfTimesWorkedByAgent[1] / 100f;
-            __result = __instance.prob + probabilityBonus;
+            var probabilityBonus = NumberOfTimesWorkedByAgent[1] / 100f;
+            __result += probabilityBonus;
 
             // Prevent potential overflow issues
             if (__result > 1f)

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -38,6 +38,12 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
                 harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb"));
                 harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
                     harmonyMethod);
+                harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("OnClickNextDay"));
+                harmonyInstance.Patch(typeof(GameSceneController).GetMethod("OnClickNextDay", AccessTools.all), null,
+                    harmonyMethod);
+                harmonyMethod = new HarmonyMethod(typeof(Harmony_Patch).GetMethod("OnStageStart"));
+                harmonyInstance.Patch(typeof(GameSceneController).GetMethod("OnStageStart", AccessTools.all), null,
+                    harmonyMethod);
             }
             catch (Exception ex)
             {
@@ -68,7 +74,6 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             var giftName = equipmentMakeInfo.equipTypeInfo.Name;
             var agentId = __instance.agent.instanceId;
             AgentWorkTracker.IncrementAgentWorkCount(giftName, agentId);
-            SaveTracker(File);
         }
 
         /// <summary>
@@ -89,6 +94,26 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             {
                 __result = 1f;
             }
+        }
+
+        /// <summary>
+        ///     Runs after the original OnClickNextDay method to save our tracker progress. We only save when going to the next
+        ///     day because it doesn't make sense that an agent would remember their creature experience if the day is reset.
+        /// </summary>
+        /// <param name="__instance">The GameSceneController instance.</param>
+        public static void OnClickNextDay([NotNull] GameSceneController __instance)
+        {
+            SaveTracker(File);
+        }
+
+        /// <summary>
+        ///     Runs after the original OnStageStart method to reset our tracker progress. We reset the progress on restart
+        ///     because it doesn't make sense that an agent would remember their creature experience if the day is reset.
+        /// </summary>
+        /// <param name="__instance">The GlobalGameManager instance.</param>
+        public static void OnStageStart([NotNull] GameSceneController __instance)
+        {
+            AgentWorkTracker = AgentWorkTracker.FromString(File.ReadAllText(TrackerFile));
         }
 
         /// <summary>

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.IO;
 using Harmony;
 using JetBrains.Annotations;
+using LobotomyCorporationMods.BadLuckProtectionForGifts.Implementations;
+using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
 using UnityEngine;
 
 // ReSharper disable InconsistentNaming
@@ -10,10 +11,17 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
     public sealed class Harmony_Patch
     {
         public static AgentWorkTracker AgentWorkTracker;
+        public static IFile File;
+        private static string JsonFile;
+        private static string LogFile;
 
         public Harmony_Patch()
         {
-            AgentWorkTracker = new AgentWorkTracker();
+            File = new File();
+            var dataPath = Application.dataPath + @"/BaseMods/";
+            JsonFile = dataPath + "BadLuckProtectionForGifts.json";
+            LogFile = dataPath + "BadLuckProtectionForGifts_Log.txt";
+            AgentWorkTracker = File.ReadFromJson(JsonFile);
             try
             {
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
@@ -26,8 +34,8 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             }
             catch (Exception ex)
             {
-                File.WriteAllText(Application.dataPath + "/BaseMods/BadLuckProtectionForGifts_Log.txt",
-                    ex.Message + Environment.NewLine + ex.StackTrace);
+                WriteToLog(File, ex.Message + Environment.NewLine + ex.StackTrace);
+                throw;
             }
         }
 
@@ -43,6 +51,26 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
             var giftName = equipmentMakeInfo.equipTypeInfo.Name;
             var agentId = __instance.agent.instanceId;
             AgentWorkTracker.IncrementAgentWorkCount(giftName, agentId);
+            WriteToJson(File);
+        }
+
+        /// <summary>
+        ///     Writes the AgentWorkTracker to a json file.
+        /// </summary>
+        /// <param name="file">The file interface.</param>
+        private static void WriteToJson([NotNull] IFile file)
+        {
+            file.WriteToJson(JsonFile, AgentWorkTracker);
+        }
+
+        /// <summary>
+        ///     Writes to a log file.
+        /// </summary>
+        /// <param name="file">The file interface.</param>
+        /// <param name="message">The message to log.</param>
+        private static void WriteToLog([NotNull] IFile file, string message)
+        {
+            file.WriteAllText(LogFile, message);
         }
 
         /// <summary>

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -20,12 +20,25 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
                 var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
                 harmonyInstance.Patch(typeof(CreatureEquipmentMakeInfo).GetMethod("GetProb", AccessTools.all), null,
                     new HarmonyMethod(typeof(Harmony_Patch).GetMethod("GetProb")));
+                harmonyInstance.Patch(typeof(UseSkill).GetMethod("FinishWorkSuccessfully", AccessTools.all),
+                    new HarmonyMethod(typeof(Harmony_Patch).GetMethod("FinishWorkSuccessfully")), null);
             }
             catch (Exception ex)
             {
                 File.WriteAllText(Application.dataPath + "/BaseMods/BadLuckProtectionForGifts_Log.txt",
                     ex.Message + Environment.NewLine + ex.StackTrace);
             }
+        }
+
+        /// <summary>
+        ///     Runs before the original FinishWorkSuccessfully method does to increment the number of times the agent
+        ///     worked on the creature.
+        /// </summary>
+        /// <param name="__instance">The UseSkill event that includes the agent data.</param>
+        public static void FinishWorkSuccessfully([NotNull] UseSkill __instance)
+        {
+            var agentId = __instance.agent.instanceId;
+            NumberOfTimesWorkedByAgent[agentId]++;
         }
 
         /// <summary>

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using Harmony;
+using UnityEngine;
+
+// ReSharper disable InconsistentNaming
+namespace LobotomyCorporationMods.BadLuckProtectionForGifts
+{
+    public class Harmony_Patch
+    {
+        public Harmony_Patch()
+        {
+            try
+            {
+                var harmonyInstance = HarmonyInstance.Create("BadLuckProtectionForGifts");
+            }
+            catch (Exception ex)
+            {
+                File.WriteAllText(Application.dataPath + "/BaseMods/BadLuckProtectionForGifts_Log.txt",
+                    ex.Message + Environment.NewLine + ex.StackTrace);
+            }
+        }
+    }
+}

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Harmony_Patch.cs
@@ -18,7 +18,7 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts
         public Harmony_Patch()
         {
             File = new File();
-            var dataPath = Application.dataPath + @"/BaseMods/";
+            var dataPath = Application.dataPath + @"/BaseMods/BadLuckProtectionForGifts/";
             JsonFile = dataPath + "BadLuckProtectionForGifts.json";
             LogFile = dataPath + "BadLuckProtectionForGifts_Log.txt";
             AgentWorkTracker = File.ReadFromJson(JsonFile);

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
@@ -10,6 +10,13 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts.Implementations
 
         public AgentWorkTracker ReadFromJson([NotNull] string path)
         {
+            if (!System.IO.File.Exists(path))
+            {
+                var tracker = new AgentWorkTracker();
+                WriteToJson(path, tracker);
+                return tracker;
+            }
+
             lock (_jsonLock)
             {
                 var json = System.IO.File.ReadAllText(path);

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
@@ -1,0 +1,34 @@
+﻿using JetBrains.Annotations;
+using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
+using UnityEngine;
+
+namespace LobotomyCorporationMods.BadLuckProtectionForGifts.Implementations
+{
+    internal sealed class File : IFile
+    {
+        private readonly object _jsonLock = new object();
+
+        public AgentWorkTracker ReadFromJson([NotNull] string path)
+        {
+            lock (_jsonLock)
+            {
+                var json = System.IO.File.ReadAllText(path);
+                return JsonUtility.FromJson<AgentWorkTracker>(json);
+            }
+        }
+
+        public void WriteAllText([NotNull] string path, string contents)
+        {
+            System.IO.File.WriteAllText(path, contents);
+        }
+
+        public void WriteToJson([NotNull] string path, object obj)
+        {
+            lock (_jsonLock)
+            {
+                var json = JsonUtility.ToJson(obj);
+                WriteAllText(path, json);
+            }
+        }
+    }
+}

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
@@ -7,6 +7,20 @@ namespace LobotomyCorporationMods.BadLuckProtectionForGifts.Implementations
     {
         private readonly object _fileLock = new object();
 
+        [NotNull]
+        public string ReadAllText([NotNull] string path)
+        {
+            if (!System.IO.File.Exists(path))
+            {
+                return string.Empty;
+            }
+
+            lock (_fileLock)
+            {
+                return System.IO.File.ReadAllText(path);
+            }
+        }
+
         public void WriteAllText([NotNull] string path, string contents)
         {
             lock (_fileLock)

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Implementations/File.cs
@@ -1,40 +1,17 @@
 ﻿using JetBrains.Annotations;
 using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
-using UnityEngine;
 
 namespace LobotomyCorporationMods.BadLuckProtectionForGifts.Implementations
 {
     internal sealed class File : IFile
     {
-        private readonly object _jsonLock = new object();
-
-        public AgentWorkTracker ReadFromJson([NotNull] string path)
-        {
-            if (!System.IO.File.Exists(path))
-            {
-                var tracker = new AgentWorkTracker();
-                WriteToJson(path, tracker);
-                return tracker;
-            }
-
-            lock (_jsonLock)
-            {
-                var json = System.IO.File.ReadAllText(path);
-                return JsonUtility.FromJson<AgentWorkTracker>(json);
-            }
-        }
+        private readonly object _fileLock = new object();
 
         public void WriteAllText([NotNull] string path, string contents)
         {
-            System.IO.File.WriteAllText(path, contents);
-        }
-
-        public void WriteToJson([NotNull] string path, object obj)
-        {
-            lock (_jsonLock)
+            lock (_fileLock)
             {
-                var json = JsonUtility.ToJson(obj);
-                WriteAllText(path, json);
+                System.IO.File.WriteAllText(path, contents);
             }
         }
     }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Interfaces/IFile.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Interfaces/IFile.cs
@@ -2,8 +2,6 @@
 {
     public interface IFile
     {
-        AgentWorkTracker ReadFromJson(string path);
         void WriteAllText(string path, string contents);
-        void WriteToJson(string path, object obj);
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Interfaces/IFile.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Interfaces/IFile.cs
@@ -1,0 +1,9 @@
+﻿namespace LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces
+{
+    public interface IFile
+    {
+        AgentWorkTracker ReadFromJson(string path);
+        void WriteAllText(string path, string contents);
+        void WriteToJson(string path, object obj);
+    }
+}

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/Interfaces/IFile.cs
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/Interfaces/IFile.cs
@@ -2,6 +2,7 @@
 {
     public interface IFile
     {
+        string ReadAllText(string path);
         void WriteAllText(string path, string contents);
     }
 }

--- a/LobotomyCorporationMods.BadLuckProtectionForGifts/LobotomyCorporationMods.BadLuckProtectionForGifts.csproj
+++ b/LobotomyCorporationMods.BadLuckProtectionForGifts/LobotomyCorporationMods.BadLuckProtectionForGifts.csproj
@@ -1,0 +1,250 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net35</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="0Harmony, Version=1.0.9.1, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath>..\..\..\..\Managed\Mono.Security.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\mscorlib.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\System.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\System.Core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\System.Xml.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AccessibilityModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.AIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ARModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ARModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ClothModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ClothModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ClusterInputModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ClusterRendererModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CrashReportingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.DirectorModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.DirectorModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.GameCenterModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.GameCenterModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.GridModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.GridModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.InputModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.InputModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.JSONSerializeModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.Networking.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ParticlesLegacyModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ParticlesLegacyModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.PerformanceReportingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.Physics2DModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ScreenCaptureModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SharedInternalsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SpatialTracking, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.SpatialTracking.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SpriteMaskModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SpriteShapeModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.StandardEvents, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.StandardEvents.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.StyleSheetsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.StyleSheetsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TerrainModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.TerrainModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TerrainPhysicsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TilemapModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.TilemapModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.Timeline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.Timeline.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UNETModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UNETModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityAnalyticsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityConnectModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VehiclesModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.VehiclesModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VideoModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.VideoModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VRModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.VRModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.WebModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.WebModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.WindModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\UnityEngine.WindModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -48,6 +48,19 @@ namespace LobotomyCorporationMods.Test
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [InlineData("Test^1;1")]
+        [InlineData("Test^1;1^2;2", GiftName, 2, 2f)]
+        [InlineData("Test^1;1^2;2|Second^1;3", "Second", 1, 3f)]
+        public void LoadingDataFromSavedTrackerPopulatesAValidAgentWorkTracker(string trackerData,
+            string giftName = GiftName, long agentId = AgentId, float numberOfTimes = 1f)
+        {
+            Harmony_Patch.AgentWorkTracker = AgentWorkTracker.FromString(trackerData);
+            var tracker = Harmony_Patch.AgentWorkTracker;
+            var expected = numberOfTimes;
+            Assert.Equal(expected, tracker.GetAgentWorkCount(giftName, agentId));
+        }
+
         [Fact]
         public void ProbabilityBonusDoesNotCauseProbabilityToGoOverOneHundredPercent()
         {

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -20,11 +20,11 @@ namespace LobotomyCorporationMods.Test
         {
             // 101 times worked would equal 101% bonus normally
             Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId] = 101f;
-            _creatureEquipmentMakeInfo.prob = 0.01f;
 
             // We should only get back 100% even with the 101% bonus
             const float expected = 1f;
-            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
+            var actual = 0f;
+            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
             Assert.Equal(expected, actual);
         }
 
@@ -34,23 +34,9 @@ namespace LobotomyCorporationMods.Test
         public void ProbabilityIncreasesByOnePercentForEveryTimeAgentWorkedOnCreature(float numberOfTimes)
         {
             Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId] = numberOfTimes;
-            _creatureEquipmentMakeInfo.prob = 0.01f;
-            var probabilityBonus = numberOfTimes / 100f;
-            var expected = probabilityBonus + 0.01f;
-            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData(0f)]
-        [InlineData(0.01f)]
-        [InlineData(0.1f)]
-        [InlineData(1f)]
-        public void ValidProbabilityIsReturnedFirstTimeThatAgentWorksOnCreature(float probability)
-        {
-            _creatureEquipmentMakeInfo.prob = probability;
-            var expected = _creatureEquipmentMakeInfo.prob;
-            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
+            var expected = numberOfTimes / 100f;
+            var actual = 0f;
+            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
             Assert.Equal(expected, actual);
         }
     }

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -8,19 +8,15 @@ namespace LobotomyCorporationMods.Test
     {
         private const long AgentId = 1;
         private const string GiftName = "Test";
-        private readonly CreatureEquipmentMakeInfo _creatureEquipmentMakeInfo;
-        private readonly UseSkill _useSkill;
-
-        public BadLuckProtectionForGiftsTests()
-        {
-            _creatureEquipmentMakeInfo = new FakeCreatureEquipmentMakeInfo(GiftName);
-            _useSkill = new FakeUseSkill(GiftName, AgentId);
-            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
-        }
+        private CreatureEquipmentMakeInfo _creatureEquipmentMakeInfo;
+        private UseSkill _useSkill;
 
         [Fact]
         public void ProbabilityBonusDoesNotCauseProbabilityToGoOverOneHundredPercent()
         {
+            _creatureEquipmentMakeInfo = new FakeCreatureEquipmentMakeInfo(GiftName);
+            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
+
             // 101 times worked would equal 101% bonus normally
             Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId, 101f);
 
@@ -36,7 +32,10 @@ namespace LobotomyCorporationMods.Test
         [InlineData(2f)]
         public void ProbabilityIncreasesByOnePercentForEveryTimeAgentWorkedOnCreature(float numberOfTimes)
         {
+            Harmony_Patch.File = new FakeFile();
+            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
             Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId, numberOfTimes);
+            _creatureEquipmentMakeInfo = new FakeCreatureEquipmentMakeInfo(GiftName);
             var expected = numberOfTimes / 100f;
             var actual = 0f;
             Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
@@ -46,6 +45,9 @@ namespace LobotomyCorporationMods.Test
         [Fact]
         public void WorkingOnCreatureIncreasesNumberOfTimesWorkedForThatAgent()
         {
+            _useSkill = new FakeUseSkill(GiftName, AgentId);
+            Harmony_Patch.File = new FakeFile();
+            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
             var expected = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId) + 1;
             Harmony_Patch.FinishWorkSuccessfully(_useSkill);
             var actual = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId);

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -27,6 +27,18 @@ namespace LobotomyCorporationMods.Test
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void StartingANewGameResetsAgentWorkProgress()
+        {
+            Harmony_Patch.File = new FakeFile();
+            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
+            var expected = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId);
+            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId);
+            Harmony_Patch.CallNewGame(new AlterTitleController());
+            var actual = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId);
+            Assert.Equal(expected, actual);
+        }
+
         [Theory]
         [InlineData(1f)]
         [InlineData(2f)]

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -1,17 +1,26 @@
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using LobotomyCorporationMods.BadLuckProtectionForGifts;
 using Xunit;
 
 namespace LobotomyCorporationMods.Test
 {
-    public class BadLuckProtectionForGiftsTests
+    public sealed class BadLuckProtectionForGiftsTests
     {
         private const long AgentId = 1;
         private readonly CreatureEquipmentMakeInfo _creatureEquipmentMakeInfo;
+        private readonly UseSkill _useSkill;
 
         public BadLuckProtectionForGiftsTests()
         {
             _creatureEquipmentMakeInfo = new CreatureEquipmentMakeInfo();
+            _useSkill = new UseSkill
+            {
+                // Calling the AgentModel constructor throws an exception, so we need to create an instance without
+                // calling the constructor.
+                agent = (AgentModel)FormatterServices.GetSafeUninitializedObject(typeof(AgentModel))
+            };
+            _useSkill.agent.instanceId = AgentId;
             Harmony_Patch.NumberOfTimesWorkedByAgent = new Dictionary<long, float> {{AgentId, 0f}};
         }
 
@@ -37,6 +46,15 @@ namespace LobotomyCorporationMods.Test
             var expected = numberOfTimes / 100f;
             var actual = 0f;
             Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void WorkingOnCreatureIncreasesNumberOfTimesWorkedForThatAgent()
+        {
+            var expected = Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId] + 1;
+            Harmony_Patch.FinishWorkSuccessfully(_useSkill);
+            var actual = Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId];
             Assert.Equal(expected, actual);
         }
     }

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using LobotomyCorporationMods.BadLuckProtectionForGifts;
 using Xunit;
 
@@ -5,11 +6,26 @@ namespace LobotomyCorporationMods.Test
 {
     public class BadLuckProtectionForGiftsTests
     {
+        private const long AgentId = 1;
         private readonly CreatureEquipmentMakeInfo _creatureEquipmentMakeInfo;
 
         public BadLuckProtectionForGiftsTests()
         {
             _creatureEquipmentMakeInfo = new CreatureEquipmentMakeInfo();
+            Harmony_Patch.NumberOfTimesWorkedByAgent = new Dictionary<long, float> {{AgentId, 0f}};
+        }
+
+        [Theory]
+        [InlineData(1f)]
+        [InlineData(2f)]
+        public void ProbabilityIncreasesByOnePercentForEveryTimeAgentWorkedOnCreature(float numberOfTimes)
+        {
+            Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId] = numberOfTimes;
+            _creatureEquipmentMakeInfo.prob = 0.01f;
+            var probabilityBonus = numberOfTimes / 100;
+            var expected = probabilityBonus + 0.01f;
+            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -6,22 +6,72 @@ namespace LobotomyCorporationMods.Test
 {
     public sealed class BadLuckProtectionForGiftsTests
     {
-        private const long AgentId = 1;
-        private const string GiftName = "Test";
         private CreatureEquipmentMakeInfo _creatureEquipmentMakeInfo;
         private UseSkill _useSkill;
+        private const long AgentId = 1;
+        private const string GiftName = "Test";
+
+        private static void IncrementAgentWorkCount(string giftName = GiftName, long agentId = AgentId,
+            float numberOfTimes = 1f)
+        {
+            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
+            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(giftName, agentId, numberOfTimes);
+        }
+
+        [Fact]
+        public void ConvertingTrackerToStringContainsDataInTracker()
+        {
+            const string secondGiftName = "Second";
+            const long secondAgentId = AgentId + 1;
+            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
+
+            // First gift first agent
+            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId);
+
+            // First gift second agent
+            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, secondAgentId);
+
+            // Second gift second agent
+            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(secondGiftName, secondAgentId, 2f);
+            var expected =
+                $@"{GiftName}^{AgentId.ToString()};1^{secondAgentId.ToString()};1|{secondGiftName}^{secondAgentId.ToString()};2";
+            var actual = Harmony_Patch.AgentWorkTracker.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ConvertingTrackerToStringWithSingleGiftAndSingleAgentReturnsCorrectString()
+        {
+            IncrementAgentWorkCount();
+            var expected = $@"{GiftName}^{AgentId.ToString()};1";
+            var actual = Harmony_Patch.AgentWorkTracker.ToString();
+            Assert.Equal(expected, actual);
+        }
 
         [Fact]
         public void ProbabilityBonusDoesNotCauseProbabilityToGoOverOneHundredPercent()
         {
             _creatureEquipmentMakeInfo = new FakeCreatureEquipmentMakeInfo(GiftName);
-            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
 
             // 101 times worked would equal 101% bonus normally
-            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId, 101f);
+            IncrementAgentWorkCount(GiftName, AgentId, 101f);
 
             // We should only get back 100% even with the 101% bonus
             const float expected = 1f;
+            var actual = 0f;
+            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(1f)]
+        [InlineData(2f)]
+        public void ProbabilityIncreasesByOnePercentForEveryTimeAgentWorkedOnCreature(float numberOfTimes)
+        {
+            Harmony_Patch.File = new FakeFile();
+            IncrementAgentWorkCount(GiftName, AgentId, numberOfTimes);
+            _creatureEquipmentMakeInfo = new FakeCreatureEquipmentMakeInfo(GiftName);
+            var expected = numberOfTimes / 100f;
             var actual = 0f;
             Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
             Assert.Equal(expected, actual);
@@ -36,21 +86,6 @@ namespace LobotomyCorporationMods.Test
             Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId);
             Harmony_Patch.CallNewgame(new AlterTitleController());
             var actual = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId);
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData(1f)]
-        [InlineData(2f)]
-        public void ProbabilityIncreasesByOnePercentForEveryTimeAgentWorkedOnCreature(float numberOfTimes)
-        {
-            Harmony_Patch.File = new FakeFile();
-            Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
-            Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId, numberOfTimes);
-            _creatureEquipmentMakeInfo = new FakeCreatureEquipmentMakeInfo(GiftName);
-            var expected = numberOfTimes / 100f;
-            var actual = 0f;
-            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, ref actual);
             Assert.Equal(expected, actual);
         }
 

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -15,6 +15,19 @@ namespace LobotomyCorporationMods.Test
             Harmony_Patch.NumberOfTimesWorkedByAgent = new Dictionary<long, float> {{AgentId, 0f}};
         }
 
+        [Fact]
+        public void ProbabilityBonusDoesNotCauseProbabilityToGoOverOneHundredPercent()
+        {
+            // 101 times worked would equal 101% bonus normally
+            Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId] = 101f;
+            _creatureEquipmentMakeInfo.prob = 0.01f;
+
+            // We should only get back 100% even with the 101% bonus
+            const float expected = 1f;
+            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
+            Assert.Equal(expected, actual);
+        }
+
         [Theory]
         [InlineData(1f)]
         [InlineData(2f)]
@@ -22,7 +35,7 @@ namespace LobotomyCorporationMods.Test
         {
             Harmony_Patch.NumberOfTimesWorkedByAgent[AgentId] = numberOfTimes;
             _creatureEquipmentMakeInfo.prob = 0.01f;
-            var probabilityBonus = numberOfTimes / 100;
+            var probabilityBonus = numberOfTimes / 100f;
             var expected = probabilityBonus + 0.01f;
             Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
             Assert.Equal(expected, actual);

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -1,0 +1,28 @@
+using LobotomyCorporationMods.BadLuckProtectionForGifts;
+using Xunit;
+
+namespace LobotomyCorporationMods.Test
+{
+    public class BadLuckProtectionForGiftsTests
+    {
+        private readonly CreatureEquipmentMakeInfo _creatureEquipmentMakeInfo;
+
+        public BadLuckProtectionForGiftsTests()
+        {
+            _creatureEquipmentMakeInfo = new CreatureEquipmentMakeInfo();
+        }
+
+        [Theory]
+        [InlineData(0f)]
+        [InlineData(0.01f)]
+        [InlineData(0.1f)]
+        [InlineData(1f)]
+        public void ValidProbabilityIsReturnedFirstTimeThatAgentWorksOnCreature(float probability)
+        {
+            _creatureEquipmentMakeInfo.prob = probability;
+            var expected = _creatureEquipmentMakeInfo.prob;
+            Harmony_Patch.GetProb(_creatureEquipmentMakeInfo, out var actual);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
+++ b/LobotomyCorporationMods.Test/BadLuckProtectionForGiftsTests.cs
@@ -34,7 +34,7 @@ namespace LobotomyCorporationMods.Test
             Harmony_Patch.AgentWorkTracker = new AgentWorkTracker();
             var expected = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId);
             Harmony_Patch.AgentWorkTracker.IncrementAgentWorkCount(GiftName, AgentId);
-            Harmony_Patch.CallNewGame(new AlterTitleController());
+            Harmony_Patch.CallNewgame(new AlterTitleController());
             var actual = Harmony_Patch.AgentWorkTracker.GetAgentWorkCount(GiftName, AgentId);
             Assert.Equal(expected, actual);
         }

--- a/LobotomyCorporationMods.Test/Fakes/FakeCreatureEquipmentMakeInfo.cs
+++ b/LobotomyCorporationMods.Test/Fakes/FakeCreatureEquipmentMakeInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace LobotomyCorporationMods.Test.Fakes
+{
+    internal sealed class FakeCreatureEquipmentMakeInfo : CreatureEquipmentMakeInfo
+    {
+        public FakeCreatureEquipmentMakeInfo(string giftName)
+        {
+            equipTypeInfo = new EquipmentTypeInfo
+            {
+                localizeData = new Dictionary<string, string> {{"name", giftName}},
+                type = EquipmentTypeInfo.EquipmentType.SPECIAL
+            };
+            LocalizeTextDataModel.instance.Init(new Dictionary<string, string> {{giftName, giftName}});
+        }
+    }
+}

--- a/LobotomyCorporationMods.Test/Fakes/FakeFile.cs
+++ b/LobotomyCorporationMods.Test/Fakes/FakeFile.cs
@@ -1,22 +1,10 @@
-﻿using LobotomyCorporationMods.BadLuckProtectionForGifts;
-using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
+﻿using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
 
 namespace LobotomyCorporationMods.Test.Fakes
 {
     internal sealed class FakeFile : IFile
     {
-        private readonly AgentWorkTracker _tracker = new AgentWorkTracker();
-
-        public AgentWorkTracker ReadFromJson(string path)
-        {
-            return _tracker;
-        }
-
         public void WriteAllText(string path, string contents)
-        {
-        }
-
-        public void WriteToJson(string path, object obj)
         {
         }
     }

--- a/LobotomyCorporationMods.Test/Fakes/FakeFile.cs
+++ b/LobotomyCorporationMods.Test/Fakes/FakeFile.cs
@@ -4,6 +4,11 @@ namespace LobotomyCorporationMods.Test.Fakes
 {
     internal sealed class FakeFile : IFile
     {
+        public string ReadAllText(string path)
+        {
+            return string.Empty;
+        }
+
         public void WriteAllText(string path, string contents)
         {
         }

--- a/LobotomyCorporationMods.Test/Fakes/FakeFile.cs
+++ b/LobotomyCorporationMods.Test/Fakes/FakeFile.cs
@@ -1,0 +1,23 @@
+﻿using LobotomyCorporationMods.BadLuckProtectionForGifts;
+using LobotomyCorporationMods.BadLuckProtectionForGifts.Interfaces;
+
+namespace LobotomyCorporationMods.Test.Fakes
+{
+    internal sealed class FakeFile : IFile
+    {
+        private readonly AgentWorkTracker _tracker = new AgentWorkTracker();
+
+        public AgentWorkTracker ReadFromJson(string path)
+        {
+            return _tracker;
+        }
+
+        public void WriteAllText(string path, string contents)
+        {
+        }
+
+        public void WriteToJson(string path, object obj)
+        {
+        }
+    }
+}

--- a/LobotomyCorporationMods.Test/Fakes/FakeUseSkill.cs
+++ b/LobotomyCorporationMods.Test/Fakes/FakeUseSkill.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace LobotomyCorporationMods.Test.Fakes
+{
+    internal sealed class FakeUseSkill : UseSkill
+    {
+        public FakeUseSkill(string giftName, long agentId)
+        {
+            // Calling one of these constructors throws an exception, so we need to create an instance without
+            // calling the constructor.
+            agent = (AgentModel)FormatterServices.GetSafeUninitializedObject(typeof(AgentModel));
+            agent.instanceId = agentId;
+            targetCreature = (CreatureModel)FormatterServices.GetSafeUninitializedObject(typeof(CreatureModel));
+            targetCreature.metaInfo = new CreatureTypeInfo
+            {
+                equipMakeInfos = new List<CreatureEquipmentMakeInfo> {new FakeCreatureEquipmentMakeInfo(giftName)}
+            };
+        }
+    }
+}

--- a/LobotomyCorporationMods.Test/LobotomyCorporationMods.Test.csproj
+++ b/LobotomyCorporationMods.Test/LobotomyCorporationMods.Test.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+
+    <IsPackable>false</IsPackable>
+
+    <OutputType>Library</OutputType>
+
+    <TargetFrameworks>net48</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="xunit" Version="2.4.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
+    <PackageReference Include="coverlet.collector" Version="1.2.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LobotomyCorporationMods.BadLuckProtectionForGifts\LobotomyCorporationMods.BadLuckProtectionForGifts.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="0Harmony, Version=1.0.9.1, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath>..\..\..\..\Managed\Mono.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\System.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\System.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <HintPath>..\..\..\..\Managed\System.Xml.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/LobotomyCorporationMods.Test/LobotomyCorporationMods.Test.csproj
+++ b/LobotomyCorporationMods.Test/LobotomyCorporationMods.Test.csproj
@@ -10,7 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="6.2.1"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="Moq" Version="4.14.6"/>
     <PackageReference Include="xunit" Version="2.4.0"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
     <PackageReference Include="coverlet.collector" Version="1.2.0"/>

--- a/LobotomyCorporationMods.Test/LobotomyCorporationMods.Test.csproj
+++ b/LobotomyCorporationMods.Test/LobotomyCorporationMods.Test.csproj
@@ -10,9 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="6.2.1"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
-    <PackageReference Include="Moq" Version="4.14.6"/>
     <PackageReference Include="xunit" Version="2.4.0"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
     <PackageReference Include="coverlet.collector" Version="1.2.0"/>

--- a/LobotomyCorporationMods.sln
+++ b/LobotomyCorporationMods.sln
@@ -1,10 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LobotomyCorporationMods.BadLuckProtectionForGifts", "LobotomyCorporationMods.BadLuckProtectionForGifts\LobotomyCorporationMods.BadLuckProtectionForGifts.csproj", "{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/LobotomyCorporationMods.sln
+++ b/LobotomyCorporationMods.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LobotomyCorporationMods.BadLuckProtectionForGifts", "LobotomyCorporationMods.BadLuckProtectionForGifts\LobotomyCorporationMods.BadLuckProtectionForGifts.csproj", "{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LobotomyCorporationMods.Test", "LobotomyCorporationMods.Test\LobotomyCorporationMods.Test.csproj", "{5186F30E-9617-4955-BE97-0E496DE2148B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19D3E31B-FA1A-4C4C-A747-CD060FA9937F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5186F30E-9617-4955-BE97-0E496DE2148B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5186F30E-9617-4955-BE97-0E496DE2148B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5186F30E-9617-4955-BE97-0E496DE2148B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5186F30E-9617-4955-BE97-0E496DE2148B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Created a new mod that provides increasing bad luck protection for agents that work on abnormalities to receive a gift from that abnormality. The rationale is that as an agent works with an abnormality they become more familiar with it, which in turn means they should be more likely to receive a gift from it. It tracks the work count for each agent for each gift, so only the work that agent puts towards that gift will count. Work counts are saved across days, but only if the day is completed; if the day is reset then all the work counts incremented during that day will reset as well and will go back to the numbers they were when the day was started. It wouldn't make sense for an agent to remember what happened after the day is reset.