### PR TITLE
Add versioning to Common DLL

### DIFF
--- a/LobotomyCorporationMods.Common/Implementations/FileManager.cs
+++ b/LobotomyCorporationMods.Common/Implementations/FileManager.cs
@@ -28,9 +28,9 @@ namespace LobotomyCorporationMods.Common.Implementations
 
         public string GetFile([NotNull] string fileName)
         {
-            if (_files.ContainsKey(fileName))
+            if (_files.TryGetValue(fileName, out var value))
             {
-                return _files[fileName];
+                return value;
             }
 
             var fullFilePath = Path.Combine(_dataPath.FullName, fileName);

--- a/LobotomyCorporationMods.Common/LobotomyCorporationMods.Common.csproj
+++ b/LobotomyCorporationMods.Common/LobotomyCorporationMods.Common.csproj
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <!--
+      Needed to prevent crashes. When Basemod loads the mods, if it finds two DLLs with the same assembly name then it
+      will try to re-use the first DLL even if the second DLL has a different assembly version.
+    -->
+    <AssemblyName>LobotomyCorporationMods.Common.$(AssemblyVersion)</AssemblyName>
     <OutputPath>bin\</OutputPath>
     <OutputType>Library</OutputType>
     <ProjectGuid>{D9BB018C-8BB3-4639-983C-F58969C8574E}</ProjectGuid>
@@ -12,11 +18,6 @@
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <IsPackable>false</IsPackable>
-    <!--
-      Needed to prevent crashes. When Basemod loads the mods, if it finds two DLLs with the same assembly name then it
-      will try to re-use the first DLL even if the second DLL has a different assembly version.
-    -->
-    <AssemblyName>LobotomyCorporationMods.Common.$([System.DateTime]::Now.ToString(yyyyMMdd))</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/LobotomyCorporationMods.Common/LobotomyCorporationMods.Common.csproj
+++ b/LobotomyCorporationMods.Common/LobotomyCorporationMods.Common.csproj
@@ -275,10 +275,8 @@
   </ItemGroup>
   <Target Name="CompleteClean" AfterTargets="Clean">
     <!-- common vars https://msdn.microsoft.com/en-us/library/c02as0cs.aspx?f=255&MSPPError=-2147217396 -->
-    <RemoveDir Directories="$(TargetDir)"/>
     <!-- bin -->
-    <RemoveDir Directories="$(ProjectDir)$(BaseIntermediateOutputPath)"/>
-    <!-- obj -->
+    <RemoveDir Directories="$(TargetDir)"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
The Common DLL will now use a version number in the name rather than a date. This makes it clearer when the Common DLL is actually updated and provides a method of versioning releases.

Major version is the number of mods implemented.
Minor version is for updates to existing mods or if a bug fix requires breaking changes.
Patch version is for non-breaking bug fixes.
Fourth octet won't be used for now.

