### PR TITLE
Fix brooches not notifying when received

### DIFF
--- a/LobotomyCorporationMods.Common/Extensions/UnitModelExtensions.cs
+++ b/LobotomyCorporationMods.Common/Extensions/UnitModelExtensions.cs
@@ -30,11 +30,14 @@ namespace LobotomyCorporationMods.Common.Extensions
         }
 
         internal static EGOgiftModel FindGiftAtPosition([NotNull] this UnitModel unitModel,
-            string position)
+            [NotNull] EquipmentTypeInfo equipmentTypeInfo)
         {
+            var position = equipmentTypeInfo.attachPos;
+            var attachType = equipmentTypeInfo.attachType;
+
             var equippedGifts = unitModel.GetEquippedGifts();
 
-            return equippedGifts.Find(g => g.metaInfo.attachPos == position);
+            return equippedGifts.Find(g => g.metaInfo.attachPos == position && g.metaInfo.attachType == attachType);
         }
 
         internal static bool IsGiftLocked([NotNull] this UnitModel unitModel,

--- a/LobotomyCorporationMods.Common/Implementations/Facades/GiftFacade.cs
+++ b/LobotomyCorporationMods.Common/Implementations/Facades/GiftFacade.cs
@@ -64,22 +64,12 @@ namespace LobotomyCorporationMods.Common.Implementations.Facades
             return unitModel.GetEquippedGifts().Exists(model => model.metaInfo.attachPos.Equals(positionName, StringComparison.OrdinalIgnoreCase) && model.metaInfo.attachType.Equals(attachType));
         }
 
-        /// <summary>Some gifts are in special slots that don't show up in an agent's gift window and are used for abnormality effect, for example, Snow Queen's icicle</summary>
-        /// <param name="equipmentModel">The equipment to check.</param>
-        /// <returns>True if the equipment is in a valid slot, otherwise false.</returns>
-        public static bool IsInValidSlot([NotNull] this EquipmentModel equipmentModel)
-        {
-            Guard.Against.Null(equipmentModel, nameof(equipmentModel));
-
-            return !equipmentModel.metaInfo.attachPos.Equals(EGOgiftAttachRegion.BODY_UP.ToString(), StringComparison.OrdinalIgnoreCase);
-        }
-
         public static bool PositionHasLockedGift([NotNull] this UnitModel unitModel,
             [NotNull] EquipmentModel gift)
         {
             Guard.Against.Null(gift, nameof(gift));
 
-            var matchingGiftAtPosition = unitModel.FindGiftAtPosition(gift.metaInfo.attachPos);
+            var matchingGiftAtPosition = unitModel.FindGiftAtPosition(gift.metaInfo);
 
             return !matchingGiftAtPosition.IsNull() && unitModel.IsGiftLocked(matchingGiftAtPosition.metaInfo.id);
         }

--- a/LobotomyCorporationMods.Common/LobotomyCorporationMods.Common.csproj
+++ b/LobotomyCorporationMods.Common/LobotomyCorporationMods.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <AssemblyVersion>6.0.2</AssemblyVersion>
+    <AssemblyVersion>6.0.3</AssemblyVersion>
     <!--
       Needed to prevent crashes. When Basemod loads the mods, if it finds two DLLs with the same assembly name then it
       will try to re-use the first DLL even if the second DLL has a different assembly version.

--- a/LobotomyCorporationMods.NotifyWhenAgentReceivesGift/Patches/UnitModelPatchAttachEgoGift.cs
+++ b/LobotomyCorporationMods.NotifyWhenAgentReceivesGift/Patches/UnitModelPatchAttachEgoGift.cs
@@ -28,13 +28,6 @@ namespace LobotomyCorporationMods.NotifyWhenAgentReceivesGift.Patches
             Guard.Against.Null(instance, nameof(instance));
             Guard.Against.Null(gift, nameof(gift));
 
-            // Some gifts are in special slots that don't show up in an agent's gift window and are used for abnormality effects.
-            // For example, Snow Queen's icicle
-            if (!gift.IsInValidSlot())
-            {
-                return;
-            }
-
             // Check if the gift's position already has a locked gift
             if (instance.PositionHasLockedGift(gift))
             {


### PR DESCRIPTION
## Summary

Reopens work on #84 — brooches do not display a notification message when an agent receives them.

A fix was authored on this branch back in 2024-11-12 (commit `4bbae76`), but the branch was never merged. #84 was closed prematurely as COMPLETED on 2026-04-20; this PR exists to track landing the actual fix.

## ⚠ Expect major merge conflicts

This branch is ~17 months behind `main` and predates significant infrastructure churn:

- `.slnx` migration + Central Package Management
- Migration of `LobotomyCorporationMods.Common` to the external `LobotomyCorporation.Mods.Common` NuGet package
- xUnit v3 + AwesomeAssertions upgrade
- New CI system via OpenLobotomy Tooling

Two of the three files touched by the brooch fix no longer exist in `main` — they were folded into the Common NuGet package:

- `LobotomyCorporationMods.NotifyWhenAgentReceivesGift/Extensions/UnitModelExtensions.cs` (deleted)
- `LobotomyCorporationMods.NotifyWhenAgentReceivesGift/Implementations/Facades/GiftFacade.cs` (deleted)
- `LobotomyCorporationMods.NotifyWhenAgentReceivesGift/Patches/UnitModelPatchAttachEgoGift.cs` (still exists)

The second commit on this branch, `4462240 Updated common version`, is obsolete and should be dropped — Common is no longer a local project.

## Next steps

- [ ] Rebase onto `main`, drop the `Updated common version` commit, and re-apply the brooch fix against current extension points (likely helpers in `LobotomyCorporation.Mods.Common`).
- [ ] Bump `LobotomyCorporationMods.NotifyWhenAgentReceivesGift` from 1.1.0 → 1.1.1 (csproj + `Info/en/Info.xml`).
- [ ] Add CHANGELOG entry for the fix under a new Common-library umbrella version.
- [ ] Update the mod README and root README as per the documentation checklist.
- [ ] Verify via manual test that a brooch received in-game displays the notification.

Closes #84.