### PR TITLE
Automate per-mod releases: drift gate + dated snapshot releases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,7 @@ The mod's `.csproj` `<AssemblyVersion>` is the single source of truth for its ve
 
 1. Bump `<AssemblyVersion>` in the mod's `.csproj`, then run `scripts/check-versions.sh --write <ModId>` to sync the `Info/{lang}/Info.xml` display names. Update the mod `README.md`, root `CHANGELOG.md`, and `INTEGRATION_TESTING_CHECKLIST.md` as needed.
 2. After the PR merges, tag and push: `git tag <ModId>-v<X.Y.Z> && git push origin <ModId>-v<X.Y.Z>`. The `Release mod` workflow rebuilds the whole set and publishes a dated snapshot release (`Mods — <date>`, marked Latest).
-3. Upload the changed mod to Nexus by hand per `releasing/NEXUS_UPLOAD.md` (auto-upload is deferred to Phase 3b).
+3. Upload the changed mod to Nexus by hand per `releasing/NEXUS_UPLOAD.md` (auto-upload is deferred to Phase 3b — tracked in #172).
 
 The version drift gate runs in CI (`scripts/check-versions.sh --check all`): the csproj version must be well-formed and match the tag at release; the English `Info.xml` suffix must match (hard fail); other locales only warn (translator-owned). See `DOCUMENTATION_UPDATING_CHECKLIST.md` for the full runbook. `WarnWhenAgentWillDieFromWorking` versions its **major number as the count of abnormalities it warns about** — not standard SemVer.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,9 +83,15 @@ For AutoFixture-driven tests, use `[LobotomyAutoData]` / `[LobotomyInlineAutoDat
 - Instance fields: `_camelCase`; static fields: `s_camelCase`; constants: `PascalCase`
 - `.editorconfig` enforces all formatting rules
 
-## Documentation Checklist (when updating a mod)
+## Releasing a mod
 
-Update: `.csproj` version, `CHANGELOG.md`, `INTEGRATION_TESTING_CHECKLIST.md`, root `README.md`, mod `README.md`, and `Info/Info.xml`.
+The mod's `.csproj` `<AssemblyVersion>` is the single source of truth for its version. To release one mod without touching any other:
+
+1. Bump `<AssemblyVersion>` in the mod's `.csproj`, then run `scripts/check-versions.sh --write <ModId>` to sync the `Info/{lang}/Info.xml` display names. Update the mod `README.md`, root `CHANGELOG.md`, and `INTEGRATION_TESTING_CHECKLIST.md` as needed.
+2. After the PR merges, tag and push: `git tag <ModId>-v<X.Y.Z> && git push origin <ModId>-v<X.Y.Z>`. The `Release mod` workflow rebuilds the whole set and publishes a dated snapshot release (`Mods — <date>`, marked Latest).
+3. Upload the changed mod to Nexus by hand per `releasing/NEXUS_UPLOAD.md` (auto-upload is deferred to Phase 3b).
+
+The version drift gate runs in CI (`scripts/check-versions.sh --check all`): the csproj version must be well-formed and match the tag at release; the English `Info.xml` suffix must match (hard fail); other locales only warn (translator-owned). See `DOCUMENTATION_UPDATING_CHECKLIST.md` for the full runbook. `WarnWhenAgentWillDieFromWorking` versions its **major number as the count of abnormalities it warns about** — not standard SemVer.
 
 `CHANGELOG.md` is for mod users (players). Only add entries a player would notice: new features, bug fixes affecting gameplay, UI changes, new configurable options. Do NOT add infra, tooling, test, refactor, or docs changes — those belong in the PR description or commit message.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
+        env:
+          # Bind results through the environment rather than interpolating ${{ }}
+          # into the shell (GitHub Actions injection-safety best practice).
+          CI_RESULT: ${{ needs.ci.result }}
+          VERSION_CHECK_RESULT: ${{ needs.version-check.result }}
         run: |
-          if [ "${{ needs.ci.result }}" != "success" ] || [ "${{ needs.version-check.result }}" != "success" ]; then
+          if [ "$CI_RESULT" != "success" ] || [ "$VERSION_CHECK_RESULT" != "success" ]; then
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,28 @@ jobs:
       PRIVATE_REFERENCES_TOKEN: ${{ secrets.PRIVATE_REFERENCES_TOKEN }}
       PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
 
+  # Fast, dependency-free gate: the csproj <AssemblyVersion> is the source of
+  # truth; verify each mod's Info.xml display name is in sync. No .NET or game
+  # DLLs needed, so this fails fast and independently of the build.
+  version-check:
+    name: Version check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Verify version drift gate (self-tests + all mods)
+        run: |
+          bash scripts/check-versions.sh --test
+          bash scripts/check-versions.sh --check all
+
   status:
     name: CI
-    needs: [ci]
+    needs: [ci, version-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check CI result
+      - name: Check job results
         run: |
-          if [ "${{ needs.ci.result }}" != "success" ]; then
+          if [ "${{ needs.ci.result }}" != "success" ] || [ "${{ needs.version-check.result }}" != "success" ]; then
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,12 @@ jobs:
   version-check:
     name: Version check
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Verify version drift gate (self-tests + all mods)
         run: |
           bash scripts/check-versions.sh --test

--- a/.github/workflows/release-mod.yml
+++ b/.github/workflows/release-mod.yml
@@ -12,7 +12,7 @@ name: Release mod
 # The Nexus auto-upload job is intentionally not here yet — it is added in
 # Phase 3b once the official upload action's current input contract has settled
 # (>7 days, no breaking changes). Until then, Nexus uploads are manual via
-# release/NEXUS_UPLOAD.md.
+# releasing/NEXUS_UPLOAD.md.
 
 on:
   push:

--- a/.github/workflows/release-mod.yml
+++ b/.github/workflows/release-mod.yml
@@ -99,7 +99,11 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Authenticate GitHub Packages
-        run: dotnet nuget update source github --username open-lobotomy --password "${{ secrets.PACKAGES_TOKEN || github.token }}" --store-password-in-clear-text || true
+        env:
+          # Bind the token through the environment rather than interpolating ${{ }}
+          # into the shell (GitHub Actions injection-safety best practice).
+          NUGET_PASSWORD: ${{ secrets.PACKAGES_TOKEN || github.token }}
+        run: dotnet nuget update source github --username open-lobotomy --password "$NUGET_PASSWORD" --store-password-in-clear-text || true
 
       - name: Build and package all mods
         run: bash scripts/package-mods.sh "${{ runner.temp }}/artifacts"

--- a/.github/workflows/release-mod.yml
+++ b/.github/workflows/release-mod.yml
@@ -116,6 +116,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      # gh release create needs write access to create the snapshot tag and release
       contents: write
     steps:
       - name: Checkout

--- a/.github/workflows/release-mod.yml
+++ b/.github/workflows/release-mod.yml
@@ -41,6 +41,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # No git operation here needs the token: the ancestry check fetches a
+          # public ref anonymously. Don't persist credentials before the
+          # artifact-producing steps run.
+          persist-credentials: false
 
       # Everything that could let a stray tag publish unreviewed content runs
       # BEFORE any secret-bearing step (private references / packages token).
@@ -70,12 +74,16 @@ jobs:
       - name: Version gate (allowlist + tag == AssemblyVersion)
         env:
           TAG_VERSION: ${{ steps.parse.outputs.ver }}
+          # Bind the tag-derived mod id through the environment rather than
+          # interpolating ${{ }} into the shell, so a tag with shell
+          # metacharacters cannot inject commands.
+          MOD_ID: ${{ steps.parse.outputs.mod }}
         run: |
           set -euo pipefail
           # --check fails if the mod is not a known deployable mod (allowlist),
           # if the csproj <AssemblyVersion> != the tag version, or if the
           # English Info.xml display suffix is out of sync.
-          bash scripts/check-versions.sh --check "${{ steps.parse.outputs.mod }}"
+          bash scripts/check-versions.sh --check "$MOD_ID"
 
       - name: Checkout private references
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -112,6 +120,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # gh release create authenticates via GH_TOKEN, not git credentials,
+          # so nothing here needs the persisted token.
+          persist-credentials: false
 
       - name: Download artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -133,7 +145,9 @@ jobs:
           date="$(date -u +%Y.%m.%d)"
           tag="snapshot-$date"
           label="$date"
-          n=2
+          # First same-day collision becomes .1, then .2, ... (no gap): the tag
+          # is assigned before n is incremented, so starting at 1 yields .1 first.
+          n=1
           while gh release view "$tag" >/dev/null 2>&1; do
             tag="snapshot-$date.$n"; label="$date.$n"; n=$((n + 1))
           done

--- a/.github/workflows/release-mod.yml
+++ b/.github/workflows/release-mod.yml
@@ -1,0 +1,165 @@
+name: Release mod
+
+# Triggered by pushing a per-mod tag of the form <ModId>-v<X.Y.Z>
+# (for example: BugFixes-v3.0.2). The workflow rebuilds the whole mod set and
+# publishes a dated aggregate "snapshot" release that carries every mod, so the
+# Releases page always shows the full, current set with a meaningful "Latest".
+#
+# Versioning one mod touches no other mod's version: only the tagged mod's tag
+# and (in Phase 3b) its Nexus page change; the other mods are rebuilt unchanged
+# from their committed source.
+#
+# The Nexus auto-upload job is intentionally not here yet — it is added in
+# Phase 3b once the official upload action's current input contract has settled
+# (>7 days, no breaking changes). Until then, Nexus uploads are manual via
+# release/NEXUS_UPLOAD.md.
+
+on:
+  push:
+    tags:
+      - '*-v*'
+
+permissions: {}
+
+# Serialize releases so the "Latest" pointer and same-day snapshot suffixes are
+# deterministic when two mod tags are pushed close together.
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      mod: ${{ steps.parse.outputs.mod }}
+      ver: ${{ steps.parse.outputs.ver }}
+    steps:
+      - name: Checkout tagged commit (full history)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      # Everything that could let a stray tag publish unreviewed content runs
+      # BEFORE any secret-bearing step (private references / packages token).
+      - name: Parse tag and verify ancestry
+        id: parse
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          case "$tag" in
+            *-v*) : ;;
+            *) echo "::error::tag '$tag' is not in <ModId>-v<X.Y.Z> form"; exit 1 ;;
+          esac
+          mod="${tag%-v*}"
+          ver="${tag##*-v}"
+          echo "mod=$mod" >> "$GITHUB_OUTPUT"
+          echo "ver=$ver" >> "$GITHUB_OUTPUT"
+          echo "Releasing mod='$mod' version='$ver'"
+          # The tagged commit must be an ancestor of origin/main: no releasing
+          # arbitrary or unreviewed content through a tag on a side commit.
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::tagged commit $GITHUB_SHA is not an ancestor of origin/main"
+            exit 1
+          fi
+          echo "ancestry OK: $GITHUB_SHA is on main"
+
+      - name: Version gate (allowlist + tag == AssemblyVersion)
+        env:
+          TAG_VERSION: ${{ steps.parse.outputs.ver }}
+        run: |
+          set -euo pipefail
+          # --check fails if the mod is not a known deployable mod (allowlist),
+          # if the csproj <AssemblyVersion> != the tag version, or if the
+          # English Info.xml display suffix is out of sync.
+          bash scripts/check-versions.sh --check "${{ steps.parse.outputs.mod }}"
+
+      - name: Checkout private references
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          path: external/LobotomyCorp_Data
+          persist-credentials: false
+          repository: ${{ vars.PRIVATE_REFERENCES_REPO }}
+          token: ${{ secrets.PRIVATE_REFERENCES_TOKEN }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '10.x'
+
+      - name: Authenticate GitHub Packages
+        run: dotnet nuget update source github --username open-lobotomy --password "${{ secrets.PACKAGES_TOKEN || github.token }}" --store-password-in-clear-text || true
+
+      - name: Build and package all mods
+        run: bash scripts/package-mods.sh "${{ runner.temp }}/artifacts"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mods
+          path: ${{ runner.temp }}/artifacts
+          retention-days: 7
+
+  snapshot:
+    name: Publish snapshot release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: mods
+          path: artifacts
+
+      - name: Create dated snapshot release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MOD: ${{ needs.build.outputs.mod }}
+          VER: ${{ needs.build.outputs.ver }}
+        run: |
+          set -euo pipefail
+
+          # CalVer: the snapshot version is the date. If a snapshot already
+          # exists for today, append .N. The tag never contains "-v", so it
+          # cannot re-trigger this workflow.
+          date="$(date -u +%Y.%m.%d)"
+          tag="snapshot-$date"
+          label="$date"
+          n=2
+          while gh release view "$tag" >/dev/null 2>&1; do
+            tag="snapshot-$date.$n"; label="$date.$n"; n=$((n + 1))
+          done
+
+          count="$(jq 'length' artifacts/versions.json)"
+          {
+            echo "This snapshot contains all $count mods. Download **all-mods.zip** for"
+            echo "the full set, or an individual mod's zip from the assets below."
+            echo
+            echo "**Changed in this release:** \`$MOD\` v$VER"
+            echo
+            jq -r 'to_entries
+                   | (["| Mod | Version |", "| --- | --- |"]
+                      + (map("| \(.key) | \(.value) |")))
+                   | .[]' artifacts/versions.json
+            echo
+            echo "_Per-mod versions are the real signal; the snapshot version is a date-ordered marker._"
+          } > "${RUNNER_TEMP}/notes.md"
+
+          # --latest sets the "Latest" badge by flag (GitHub does not sort the
+          # version string), so dated snapshots cleanly supersede old v6.x tags.
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "Mods — $label" \
+            --notes-file "${RUNNER_TEMP}/notes.md" \
+            --latest \
+            artifacts/*.zip artifacts/versions.json
+
+          echo "Published release '$tag' (Latest) with $count mods; changed: $MOD v$VER"

--- a/.github/workflows/release-mod.yml
+++ b/.github/workflows/release-mod.yml
@@ -10,14 +10,14 @@ name: Release mod
 # from their committed source.
 #
 # The Nexus auto-upload job is intentionally not here yet — it is added in
-# Phase 3b once the official upload action's current input contract has settled
-# (>7 days, no breaking changes). Until then, Nexus uploads are manual via
-# releasing/NEXUS_UPLOAD.md.
+# Phase 3b (tracked in #172) once the official upload action's current input
+# contract has settled (>7 days, no breaking changes). Until then, Nexus
+# uploads are manual via releasing/NEXUS_UPLOAD.md.
 
 on:
   push:
     tags:
-      - '*-v*'
+      - '*-v[0-9]*'
 
 permissions: {}
 
@@ -71,7 +71,7 @@ jobs:
           fi
           echo "ancestry OK: $GITHUB_SHA is on main"
 
-      - name: Version gate (allowlist + tag == AssemblyVersion)
+      - name: Version gate (mod discovery + tag == AssemblyVersion)
         env:
           TAG_VERSION: ${{ steps.parse.outputs.ver }}
           # Bind the tag-derived mod id through the environment rather than
@@ -80,9 +80,11 @@ jobs:
           MOD_ID: ${{ steps.parse.outputs.mod }}
         run: |
           set -euo pipefail
-          # --check fails if the mod is not a known deployable mod (allowlist),
-          # if the csproj <AssemblyVersion> != the tag version, or if the
-          # English Info.xml display suffix is out of sync.
+          # --check fails if the mod is not a discovered deployable mod
+          # (discovery is dynamic: any LobotomyCorporationMods.* dir with a
+          # GlobalInfo.xml <ID> and a .csproj), if the csproj <AssemblyVersion>
+          # != the tag version, or if the English Info.xml display suffix is out
+          # of sync.
           bash scripts/check-versions.sh --check "$MOD_ID"
 
       - name: Checkout private references
@@ -103,7 +105,7 @@ jobs:
           # Bind the token through the environment rather than interpolating ${{ }}
           # into the shell (GitHub Actions injection-safety best practice).
           NUGET_PASSWORD: ${{ secrets.PACKAGES_TOKEN || github.token }}
-        run: dotnet nuget update source github --username open-lobotomy --password "$NUGET_PASSWORD" --store-password-in-clear-text || true
+        run: dotnet nuget update source github --username open-lobotomy --password "$NUGET_PASSWORD" --store-password-in-clear-text
 
       - name: Build and package all mods
         run: bash scripts/package-mods.sh "${{ runner.temp }}/artifacts"
@@ -123,13 +125,6 @@ jobs:
       # gh release create needs write access to create the snapshot tag and release
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          # gh release create authenticates via GH_TOKEN, not git credentials,
-          # so nothing here needs the persisted token.
-          persist-credentials: false
-
       - name: Download artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/DOCUMENTATION_UPDATING_CHECKLIST.md
+++ b/DOCUMENTATION_UPDATING_CHECKLIST.md
@@ -1,13 +1,44 @@
-# Documentation Updating Checklist
+# Releasing a Mod
 
-When a mod is updated, we need to make sure all the appropriate
-documentation is updated accordingly.
+Each mod is released on its own, without touching any other mod's release. The
+mod's `.csproj` `<AssemblyVersion>` is the single source of truth for its
+version; everything else is synced or generated from it.
 
-- [ ] LobotomyCorporationMods.Common.csproj file
-- [ ] CHANGELOG.md
-- [ ] INTEGRATION_TESTING_CHECKLIST.md
-- [ ] README.md
-- [ ] Mod Folder
-  - [ ] .csproj file
-  - [ ] README.md
-  - [ ] Info/Info.xml file
+## 1. Bump the version and update docs (in a pull request)
+
+- [ ] `<Mod>/<Mod>.csproj` — set `<AssemblyVersion>` to the new version.
+- [ ] Sync the in-game display names: run
+      `scripts/check-versions.sh --write <ModId>`. This rewrites the `v<X.Y.Z>`
+      suffix in every `Info/{lang}/Info.xml` `<name>` from the csproj version.
+- [ ] `<Mod>/README.md` — add a changelog entry.
+- [ ] `CHANGELOG.md` (root) — add a player-facing entry. Only add changes a
+      player would notice (features, gameplay fixes, UI, new options); not infra,
+      tooling, tests, refactors, or docs.
+- [ ] `INTEGRATION_TESTING_CHECKLIST.md` — update if the test steps changed.
+- [ ] Open the pull request. CI runs the version drift gate
+      (`scripts/check-versions.sh --check all`) alongside the build and tests.
+
+## 2. Release (after the pull request merges to `main`)
+
+- [ ] Tag the merge commit and push it:
+
+      git tag <ModId>-v<X.Y.Z>          # e.g. BugFixes-v3.0.2
+      git push origin <ModId>-v<X.Y.Z>
+
+- [ ] The **Release mod** workflow rebuilds the whole mod set and publishes a
+      dated snapshot release (`Mods — <date>`) marked **Latest**, containing
+      every mod's zip plus `all-mods.zip`.
+
+## 3. Nexus
+
+- [ ] Upload the changed mod to Nexus by hand — see
+      [releasing/NEXUS_UPLOAD.md](releasing/NEXUS_UPLOAD.md). (Automated upload is
+      planned as Phase 3b of the release pipeline.)
+
+## Notes
+
+- The version is cosmetic to LMM/Basemod (they key off the mod folder name and
+  `Info/GlobalInfo.xml <ID>`), but it is shown to users, so keep it in sync.
+- Most mods use normal SemVer. `WarnWhenAgentWillDieFromWorking` is the
+  exception: its **major version is the number of abnormalities it warns about**
+  (see that mod's README).

--- a/DOCUMENTATION_UPDATING_CHECKLIST.md
+++ b/DOCUMENTATION_UPDATING_CHECKLIST.md
@@ -33,7 +33,7 @@ version; everything else is synced or generated from it.
 
 - [ ] Upload the changed mod to Nexus by hand — see
       [releasing/NEXUS_UPLOAD.md](releasing/NEXUS_UPLOAD.md). (Automated upload is
-      planned as Phase 3b of the release pipeline.)
+      planned as Phase 3b of the release pipeline — tracked in #172.)
 
 ## Notes
 

--- a/LobotomyCorporationMods.GiftAlertIcon/Info/cn/Info.xml
+++ b/LobotomyCorporationMods.GiftAlertIcon/Info/cn/Info.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <info>
-  <name>饰品警告图标v1.0.1</name>
+  <name>饰品警告图标v1.0.2</name>
   <descs>
     <desc>当员工能够获取一个新饰品或取代已有饰品时，显示一个图标。</desc>
   </descs>

--- a/LobotomyCorporationMods.WarnWhenAgentWillDieFromWorking/README.md
+++ b/LobotomyCorporationMods.WarnWhenAgentWillDieFromWorking/README.md
@@ -76,6 +76,15 @@ Provides warnings for the following abnormalities and any of their conditions (
 - **Warm-Hearted Woodsman**
   - Qliphoth Counter is 0.
 
+## Versioning
+
+This mod uses a custom versioning scheme. The **major version number is the
+number of abnormalities the mod warns about** (the abnormalities listed above).
+For example, version 15.x.x means the mod warns about 15 abnormalities. Adding a
+warning for a new abnormality raises the major version by one. The minor and
+patch numbers change for features and fixes that do not change the number of
+abnormalities the mod warns about.
+
 ## Changelog
 
 ### [1.1.0] - 2024-06-23

--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ Requires either [Lobotomy Mod Manager](https://www.nexusmods.com/site/mods/765)
 or [Basemod](https://www.nexusmods.com/lobotomycorporation/mods/2) (included in
 LMM).
 
+## Download
+
+You can install these mods two ways. Both need
+[Lobotomy Mod Manager](https://www.nexusmods.com/site/mods/765)
+or [Basemod](https://www.nexusmods.com/lobotomycorporation/mods/2) (included in
+LMM).
+
+**From GitHub (always the newest build):**
+
+1. Open the
+   [latest release](https://github.com/CTristan/lobotomy-corporation-mods/releases/latest).
+   It is named `Mods — <date>` and contains every mod.
+2. Download `all-mods.zip` to get all mods at once, or download a single
+   `<ModName>.zip` to get just one mod.
+3. Extract the zip into your game's `LobotomyCorp_Data/BaseMods` folder. Each mod
+   becomes its own folder there (for example, `BaseMods/BugFixes`).
+4. Start the game through LMM or Basemod and turn on the mods you want.
+
+**From Nexus Mods:** open the per-mod pages listed below and download from there.
+
 ## Nexus Mods pages
 
 - [Bad Luck Protection for Gifts](https://www.nexusmods.com/lobotomycorporation/mods/476)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ LMM).
 
 ## Download
 
-You can install these mods two ways. Both need
-[Lobotomy Mod Manager](https://www.nexusmods.com/site/mods/765)
-or [Basemod](https://www.nexusmods.com/lobotomycorporation/mods/2) (included in
-LMM).
+You can install these mods two ways. Both need Lobotomy Mod Manager or Basemod
+(linked at the top of this page).
 
 **From GitHub (always the newest build):**
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ You can install these mods two ways. Both need Lobotomy Mod Manager or Basemod
 1. Open the
    [latest release](https://github.com/CTristan/lobotomy-corporation-mods/releases/latest).
    It is named `Mods — <date>` and contains every mod.
-2. Download `all-mods.zip` to get all mods at once, or download a single
-   `<ModName>.zip` to get just one mod.
+2. Download `all-mods.zip` to get all mods at once, or download a single mod's
+   zip to get just one mod. Each mod's zip is named by its ID, for example
+   `BugFixes.zip`.
 3. Extract the zip into your game's `LobotomyCorp_Data/BaseMods` folder. Each mod
    becomes its own folder there (for example, `BaseMods/BugFixes`).
 4. Start the game through LMM or Basemod and turn on the mods you want.

--- a/releasing/NEXUS_UPLOAD.md
+++ b/releasing/NEXUS_UPLOAD.md
@@ -1,0 +1,33 @@
+# Nexus upload checklist (manual)
+
+Until the automated Nexus upload lands (release pipeline Phase 3b), upload the
+changed mod to Nexus Mods by hand after the GitHub snapshot release is published.
+
+This is per-mod: upload only the mod whose version you just changed. The other
+mods on Nexus are not affected.
+
+## Mod to Nexus page
+
+| Mod (ModId) | Nexus page |
+| --- | --- |
+| BadLuckProtectionForGifts | <https://www.nexusmods.com/lobotomycorporation/mods/476> |
+| BugFixes | <https://www.nexusmods.com/lobotomycorporation/mods/478> |
+| FreeCustomization | <https://www.nexusmods.com/lobotomycorporation/mods/477> |
+| GiftAlertIcon | <https://www.nexusmods.com/lobotomycorporation/mods/494> |
+| NotifyWhenAgentReceivesGift | <https://www.nexusmods.com/lobotomycorporation/mods/487> |
+| WarnWhenAgentWillDieFromWorking | <https://www.nexusmods.com/lobotomycorporation/mods/479> |
+
+DontChatMe is not on Nexus yet. Its page must be created once by hand before its
+first upload (the Nexus upload API cannot create new pages).
+
+## Steps
+
+1. Confirm the GitHub snapshot release published and is marked **Latest**.
+2. Download the changed mod's `<ModId>.zip` from that release's assets.
+3. Open the mod's Nexus page (table above) and sign in as the mod author.
+4. Add a new file:
+   - Upload `<ModId>.zip`.
+   - Set the version to match the mod's new version — the csproj
+     `<AssemblyVersion>` (for example, `3.0.2`).
+   - Write a short description of what changed (mirror the mod's changelog).
+5. Publish, then check that the new version shows on the page.

--- a/releasing/NEXUS_UPLOAD.md
+++ b/releasing/NEXUS_UPLOAD.md
@@ -1,6 +1,6 @@
 # Nexus upload checklist (manual)
 
-Until the automated Nexus upload lands (release pipeline Phase 3b), upload the
+Until the automated Nexus upload lands (release pipeline Phase 3b — tracked in #172), upload the
 changed mod to Nexus Mods by hand after the GitHub snapshot release is published.
 
 This is per-mod: upload only the mod whose version you just changed. The other

--- a/releasing/NEXUS_UPLOAD.md
+++ b/releasing/NEXUS_UPLOAD.md
@@ -22,7 +22,7 @@ first upload (the Nexus upload API cannot create new pages).
 
 ## Steps
 
-1. Confirm the GitHub snapshot release published and is marked **Latest**.
+1. Confirm the GitHub snapshot release was published and is marked **Latest**.
 2. Download the changed mod's `<ModId>.zip` from that release's assets.
 3. Open the mod's Nexus page (table above) and sign in as the mod author.
 4. Add a new file:

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -106,7 +106,7 @@ discover_mods() {
     [[ -d "$dir" ]] || continue
     global="$dir/Info/GlobalInfo.xml"
     [[ -f "$global" ]] || continue
-    # shellcheck disable=SC2012
+    # shellcheck disable=SC2012  # mod csproj names are controlled; ls is fine
     csproj=$(ls "$dir"/*.csproj 2>/dev/null | head -1 || true)
     [[ -n "$csproj" ]] || continue
     id=$(perl -ne 'if (m{<ID>\s*([^<]+?)\s*</ID>}) { print $1; exit }' "$global")
@@ -129,7 +129,7 @@ mod_dir_for() {
 # Sync one mod's Info.xml display suffixes to its csproj version; log each change.
 write_mod() {
   local id="$1" dir="$2" csproj ver f changed=0
-  # shellcheck disable=SC2012
+  # shellcheck disable=SC2012  # mod csproj names are controlled; ls is fine
   csproj=$(ls "$dir"/*.csproj | head -1)
   # Refuse to write a bad version into the display names: it would silently
   # become v0.0.0. The source of truth must be valid before we touch Info.xml.
@@ -155,8 +155,8 @@ write_mod() {
 
 # Echoes nothing; returns the number of ERRORS for this mod (warnings excluded).
 check_mod() {
-  local id="$1" dir="$2" csproj ver tagver errors=0 f lang disp
-  # shellcheck disable=SC2012
+  local id="$1" dir="$2" csproj ver tagver errors=0 f lang disp found_en=0
+  # shellcheck disable=SC2012  # mod csproj names are controlled; ls is fine
   csproj=$(ls "$dir"/*.csproj | head -1)
 
   # Primary: well-formed source of truth.
@@ -183,6 +183,7 @@ check_mod() {
   # Secondary cosmetic: per-locale display suffix.
   while IFS= read -r f; do
     lang=$(basename "$(dirname "$f")")
+    [[ "$lang" == "en" ]] && found_en=1
     disp=$(info_display_version "$f")
     if [[ -z "$disp" ]]; then
       if [[ "$lang" == "en" ]]; then
@@ -202,6 +203,14 @@ check_mod() {
       warn "$id [$lang]: display v$disp != source of truth v$ver (translator-owned; not auto-fixed)"
     fi
   done < <(find "$dir/Info" -mindepth 2 -maxdepth 2 -name 'Info.xml' 2>/dev/null | sort)
+
+  # A deployable mod must ship an English Info.xml: the launcher shows that display
+  # name, and en is the maintainer-owned baseline (other locales only warn). Without
+  # this guard, a discovered mod with zero en Info.xml passes the loop silently.
+  if [[ "$found_en" -eq 0 ]]; then
+    err "$id [en]: no Info/en/Info.xml found (required for the launcher display name)"
+    errors=$((errors + 1))
+  fi
 
   return "$errors"
 }
@@ -316,6 +325,23 @@ self_test() {
   _expect "normalized_or_fail normalizes a valid string" "$(normalized_or_fail "1.2")" "1.2.0"
   _expect_fail "normalized_or_fail rejects a v-prefixed string" normalized_or_fail "v1.0.0"
   _expect_fail "normalized_or_fail rejects an empty string" normalized_or_fail ""
+
+  # check_mod: a discovered mod with no en Info.xml must hard-fail. The cn display
+  # matches its version, so the en guard is the only possible error source.
+  mkdir -p "$tmp/mod_noen/Info/cn"
+  _csproj "1.2.0" "$tmp/mod_noen/TestNoEn.csproj"
+  _name "测试 v1.2.0" "$tmp/mod_noen/Info/cn/Info.xml"
+  _expect_fail "check_mod fails when a mod has no en Info.xml" check_mod "TestNoEn" "$tmp/mod_noen"
+
+  # check_mod: the same shape with an en Info.xml present passes (errors == 0).
+  mkdir -p "$tmp/mod_en/Info/en"
+  _csproj "1.2.0" "$tmp/mod_en/TestEn.csproj"
+  _name "Test Mod v1.2.0" "$tmp/mod_en/Info/en/Info.xml"
+  if check_mod "TestEn" "$tmp/mod_en" >/dev/null 2>&1; then
+    ok "test: check_mod passes when en Info.xml is present"; pass=$((pass + 1))
+  else
+    err "test: check_mod passes when en Info.xml is present -- unexpectedly failed"; fail=$((fail + 1))
+  fi
 
   echo
   if [[ "$fail" -gt 0 ]]; then

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# check-versions.sh — single source of truth + drift gate for mod versions.
+#
+# The csproj <AssemblyVersion> is the SOURCE OF TRUTH for every mod's version.
+# Each mod also carries a cosmetic copy of the version in the display name shown
+# by the in-game mod launcher (LMM/Basemod): Info/{lang}/Info.xml <name> ends
+# with a "v<X.Y.Z>" suffix, e.g. "Gift Alert Icon v1.0.2" (en, with a space) or
+# "饰品警告图标v1.0.2" (cn, no space). This script keeps those display suffixes
+# in sync with the source of truth and verifies them.
+#
+# Modes:
+#   --write <ModId|all>   Rewrite the trailing v<X.Y.Z> in every Info/*/Info.xml
+#                         <name> from the csproj <AssemblyVersion>, preserving
+#                         each locale's human title and separator. Sole writer.
+#   --check <ModId|all>   Verify versions.
+#                           Primary  : csproj <AssemblyVersion> is well-formed,
+#                                      and == $TAG_VERSION when that env var is
+#                                      set (release-time tag/version match).
+#                           Secondary: the English (en) display suffix matches
+#                                      the source of truth -> HARD FAIL.
+#                                      Other locales (e.g. cn) only WARN, because
+#                                      they are translator-owned text.
+#                         Exits nonzero only on a primary or English mismatch.
+#   --test                Run self-tests against golden fixtures (guards the
+#                         display-name regex, the one fragile spot).
+#
+# Mods are discovered dynamically: any LobotomyCorporationMods.* directory that
+# has both a .csproj and Info/GlobalInfo.xml is a deployable mod (the ModId is
+# that GlobalInfo's <ID>). Nothing hardcodes the mod list or count, so mods can
+# be added or removed without editing this script.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---- styling -----------------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_ERR=$'\033[31m'; C_OFF=$'\033[0m'
+else
+  C_OK=''; C_WARN=''; C_ERR=''; C_OFF=''
+fi
+ok()   { printf '%s[ ok ]%s   %s\n'   "$C_OK"   "$C_OFF" "$*"; }
+warn() { printf '%s[warn]%s   %s\n'   "$C_WARN" "$C_OFF" "$*"; }
+err()  { printf '%s[FAIL]%s   %s\n'   "$C_ERR"  "$C_OFF" "$*"; }
+
+# ---- version helpers ---------------------------------------------------------
+
+# Extract the raw <AssemblyVersion> text from a csproj (first occurrence).
+csproj_version_raw() {
+  perl -ne 'if (m{<AssemblyVersion>\s*([0-9][0-9.]*)\s*</AssemblyVersion>}) { print $1; exit }' "$1"
+}
+
+# Normalize a dotted version to exactly three components (X.Y.Z), padding 0s.
+normalize3() {
+  local v="$1" a b c IFS='.'
+  # shellcheck disable=SC2206
+  local parts=($v)
+  a="${parts[0]:-0}"; b="${parts[1]:-0}"; c="${parts[2]:-0}"
+  printf '%s.%s.%s' "$a" "$b" "$c"
+}
+
+is_well_formed() { [[ "$1" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; }
+
+# Extract the trailing display version (the LAST "v<X.Y.Z>" before </name>).
+info_display_version() {
+  perl -CSD -ne 'if (m{<name>.*v([0-9]+\.[0-9]+\.[0-9]+)</name>}) { print $1; exit }' "$1"
+}
+
+# Rewrite the trailing "v<X.Y.Z>" in a single Info.xml <name> to $2.
+# No-op if the name has no such suffix (cannot infer a title/separator).
+rewrite_info_version() {
+  local file="$1" ver="$2"
+  VER="$ver" perl -CSD -i -pe \
+    's{(<name>.*)v[0-9]+\.[0-9]+\.[0-9]+(</name>)}{${1}v$ENV{VER}${2}}' "$file"
+}
+
+# ---- mod discovery -----------------------------------------------------------
+
+# Print "ModId<TAB>dir" for every deployable mod, sorted by ModId.
+discover_mods() {
+  local dir csproj global id
+  for dir in "$ROOT"/LobotomyCorporationMods.*/; do
+    dir="${dir%/}"
+    [[ -d "$dir" ]] || continue
+    global="$dir/Info/GlobalInfo.xml"
+    [[ -f "$global" ]] || continue
+    # shellcheck disable=SC2012
+    csproj=$(ls "$dir"/*.csproj 2>/dev/null | head -1 || true)
+    [[ -n "$csproj" ]] || continue
+    id=$(perl -ne 'if (m{<ID>\s*([^<]+?)\s*</ID>}) { print $1; exit }' "$global")
+    [[ -n "$id" ]] || continue
+    printf '%s\t%s\n' "$id" "$dir"
+  done | sort
+}
+
+# Resolve a single ModId to its directory (exits nonzero if unknown).
+mod_dir_for() {
+  local want="$1" id dir
+  while IFS=$'\t' read -r id dir; do
+    [[ "$id" == "$want" ]] && { printf '%s' "$dir"; return 0; }
+  done < <(discover_mods)
+  return 1
+}
+
+# ---- write -------------------------------------------------------------------
+
+write_mod() {
+  local id="$1" dir="$2" csproj raw ver f changed=0
+  # shellcheck disable=SC2012
+  csproj=$(ls "$dir"/*.csproj | head -1)
+  raw=$(csproj_version_raw "$csproj")
+  ver=$(normalize3 "$raw")
+  while IFS= read -r f; do
+    local before after
+    before=$(cat "$f")
+    rewrite_info_version "$f" "$ver"
+    after=$(cat "$f")
+    if [[ "$before" != "$after" ]]; then
+      ok "$id: wrote v$ver -> ${f#"$ROOT"/}"
+      changed=1
+    fi
+  done < <(find "$dir/Info" -mindepth 2 -name 'Info.xml' 2>/dev/null | sort)
+  [[ "$changed" -eq 0 ]] && ok "$id: already in sync (v$ver)"
+  return 0
+}
+
+# ---- check -------------------------------------------------------------------
+# Echoes nothing; returns the number of ERRORS for this mod (warnings excluded).
+
+check_mod() {
+  local id="$1" dir="$2" csproj raw ver errors=0 f lang disp
+  # shellcheck disable=SC2012
+  csproj=$(ls "$dir"/*.csproj | head -1)
+  raw=$(csproj_version_raw "$csproj")
+
+  # Primary: well-formed source of truth.
+  if [[ -z "$raw" ]] || ! is_well_formed "$raw"; then
+    err "$id: csproj <AssemblyVersion> missing or malformed: '${raw:-<none>}'"
+    return 1
+  fi
+  ver=$(normalize3 "$raw")
+
+  # Primary: tag/version match at release time.
+  if [[ -n "${TAG_VERSION:-}" ]]; then
+    local tagver; tagver=$(normalize3 "$TAG_VERSION")
+    if [[ "$ver" != "$tagver" ]]; then
+      err "$id: tag version v$tagver != csproj <AssemblyVersion> v$ver"
+      errors=$((errors + 1))
+    else
+      ok "$id: tag v$tagver == csproj v$ver"
+    fi
+  fi
+
+  # Secondary cosmetic: per-locale display suffix.
+  while IFS= read -r f; do
+    lang=$(basename "$(dirname "$f")")
+    disp=$(info_display_version "$f")
+    if [[ -z "$disp" ]]; then
+      if [[ "$lang" == "en" ]]; then
+        err "$id [en]: no v<X.Y.Z> suffix found in <name> (expected v$ver)"
+        errors=$((errors + 1))
+      else
+        warn "$id [$lang]: no v<X.Y.Z> suffix found in <name> (expected v$ver)"
+      fi
+      continue
+    fi
+    if [[ "$disp" == "$ver" ]]; then
+      ok "$id [$lang]: display v$disp matches"
+    elif [[ "$lang" == "en" ]]; then
+      err "$id [en]: display v$disp != source of truth v$ver (run: $0 --write $id)"
+      errors=$((errors + 1))
+    else
+      warn "$id [$lang]: display v$disp != source of truth v$ver (translator-owned; not auto-fixed)"
+    fi
+  done < <(find "$dir/Info" -mindepth 2 -name 'Info.xml' 2>/dev/null | sort)
+
+  return "$errors"
+}
+
+# ---- mode dispatch -----------------------------------------------------------
+
+run_over_target() {
+  local action="$1" target="$2" id dir total_errors=0 count=0
+  if [[ "$target" == "all" ]]; then
+    while IFS=$'\t' read -r id dir; do
+      count=$((count + 1))
+      if [[ "$action" == "write" ]]; then
+        write_mod "$id" "$dir"
+      else
+        set +e; check_mod "$id" "$dir"; total_errors=$((total_errors + $?)); set -e
+      fi
+    done < <(discover_mods)
+    [[ "$count" -eq 0 ]] && { err "no mods discovered under $ROOT"; return 1; }
+  else
+    dir=$(mod_dir_for "$target") || { err "unknown mod '$target' (not a discovered mod)"; return 1; }
+    if [[ "$action" == "write" ]]; then
+      write_mod "$target" "$dir"
+    else
+      set +e; check_mod "$target" "$dir"; total_errors=$?; set -e
+    fi
+  fi
+
+  if [[ "$action" == "check" ]]; then
+    echo
+    if [[ "$total_errors" -gt 0 ]]; then
+      err "version check failed with $total_errors error(s)"
+      return 1
+    fi
+    ok "version check passed"
+  fi
+  return 0
+}
+
+# ---- self-tests --------------------------------------------------------------
+
+self_test() {
+  local tmp pass=0 fail=0 rc=0
+  tmp=$(mktemp -d)
+
+  _expect() { # desc, actual, expected
+    if [[ "$2" == "$3" ]]; then ok "test: $1"; pass=$((pass + 1));
+    else err "test: $1 -- got [$2] expected [$3]"; fail=$((fail + 1)); fi
+  }
+  _name() { printf '<info>\n  <name>%s</name>\n</info>\n' "$1" > "$2"; }
+  _read() { perl -CSD -ne 'if (m{<name>(.*)</name>}) { print $1; exit }' "$1"; }
+
+  # en with a space separator
+  _name "Gift Alert Icon v1.0.2" "$tmp/en.xml"
+  rewrite_info_version "$tmp/en.xml" "9.9.9"
+  _expect "en (space) rewrite" "$(_read "$tmp/en.xml")" "Gift Alert Icon v9.9.9"
+
+  # cn with no separator (UTF-8)
+  _name "饰品警告图标v1.0.1" "$tmp/cn.xml"
+  rewrite_info_version "$tmp/cn.xml" "1.0.2"
+  _expect "cn (no space, UTF-8) rewrite" "$(_read "$tmp/cn.xml")" "饰品警告图标v1.0.2"
+
+  # title that contains the letter v and stray digits -> must pick the LAST v<semver>
+  _name "Mod version 2 Deluxe v1.2.3" "$tmp/tricky.xml"
+  rewrite_info_version "$tmp/tricky.xml" "9.9.9"
+  _expect "tricky title rewrite" "$(_read "$tmp/tricky.xml")" "Mod version 2 Deluxe v9.9.9"
+
+  # multi-digit major (the WarnWhenDie abnormality-count convention)
+  _name "Warn When Agent Will Die From Working v15.0.0" "$tmp/multi.xml"
+  rewrite_info_version "$tmp/multi.xml" "16.0.0"
+  _expect "multi-digit major rewrite" "$(_read "$tmp/multi.xml")" "Warn When Agent Will Die From Working v16.0.0"
+
+  # no version suffix -> rewrite is a no-op
+  _name "No Version Here" "$tmp/none.xml"
+  rewrite_info_version "$tmp/none.xml" "9.9.9"
+  _expect "no-suffix is left unchanged" "$(_read "$tmp/none.xml")" "No Version Here"
+
+  # display extraction
+  _name "Gift Alert Icon v1.0.2" "$tmp/read.xml"
+  _expect "display extraction" "$(info_display_version "$tmp/read.xml")" "1.0.2"
+
+  # normalize3
+  _expect "normalize 2-part" "$(normalize3 "1.2")" "1.2.0"
+  _expect "normalize 4-part" "$(normalize3 "15.0.0.0")" "15.0.0"
+
+  echo
+  if [[ "$fail" -gt 0 ]]; then
+    err "self-tests failed: $fail failed, $pass passed"; rc=1
+  else
+    ok "self-tests passed: $pass passed"
+  fi
+  rm -rf "$tmp"
+  return "$rc"
+}
+
+# ---- entrypoint --------------------------------------------------------------
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  $0 --write <ModId|all>    rewrite Info.xml display versions from csproj
+  $0 --check <ModId|all>    verify versions (set TAG_VERSION to also match a tag)
+  $0 --test                 run self-tests
+EOF
+  exit 2
+}
+
+main() {
+  [[ $# -ge 1 ]] || usage
+  case "$1" in
+    --write) [[ $# -eq 2 ]] || usage; run_over_target write "$2" ;;
+    --check) [[ $# -eq 2 ]] || usage; run_over_target check "$2" ;;
+    --test)  [[ $# -eq 1 ]] || usage; self_test ;;
+    *) usage ;;
+  esac
+}
+
+main "$@"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -67,6 +67,17 @@ normalize3() {
 # True if $1 is a dotted version of 2-4 numeric components (e.g. 1.2 or 1.2.3.4).
 is_well_formed() { [[ "$1" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; }
 
+# Resolve a csproj's <AssemblyVersion> to a normalized X.Y.Z, echoed to stdout.
+# Returns nonzero and echoes nothing when the version is missing or malformed.
+# This is the single chokepoint so the checker, the writer, and the packager
+# all agree on what a valid version is and none silently turns a bad one into
+# "0.0.0"; callers report the failure (with the offending csproj path).
+resolved_version() {
+  local raw; raw=$(csproj_version_raw "$1")
+  is_well_formed "$raw" || return 1
+  normalize3 "$raw"
+}
+
 # Extract the trailing display version (the LAST "v<X.Y.Z>" before </name>).
 info_display_version() {
   perl -CSD -ne 'if (m{<name>.*v([0-9]+\.[0-9]+\.[0-9]+)</name>}) { print $1; exit }' "$1"
@@ -112,11 +123,15 @@ mod_dir_for() {
 
 # Sync one mod's Info.xml display suffixes to its csproj version; log each change.
 write_mod() {
-  local id="$1" dir="$2" csproj raw ver f changed=0
+  local id="$1" dir="$2" csproj ver f changed=0
   # shellcheck disable=SC2012
   csproj=$(ls "$dir"/*.csproj | head -1)
-  raw=$(csproj_version_raw "$csproj")
-  ver=$(normalize3 "$raw")
+  # Refuse to write a bad version into the display names: it would silently
+  # become v0.0.0. The source of truth must be valid before we touch Info.xml.
+  if ! ver=$(resolved_version "$csproj"); then
+    err "$id: csproj <AssemblyVersion> missing or malformed; refusing to write (${csproj#"$ROOT"/})"
+    return 1
+  fi
   while IFS= read -r f; do
     local before after
     before=$(cat "$f")
@@ -135,17 +150,15 @@ write_mod() {
 
 # Echoes nothing; returns the number of ERRORS for this mod (warnings excluded).
 check_mod() {
-  local id="$1" dir="$2" csproj raw ver errors=0 f lang disp
+  local id="$1" dir="$2" csproj ver errors=0 f lang disp
   # shellcheck disable=SC2012
   csproj=$(ls "$dir"/*.csproj | head -1)
-  raw=$(csproj_version_raw "$csproj")
 
   # Primary: well-formed source of truth.
-  if [[ -z "$raw" ]] || ! is_well_formed "$raw"; then
-    err "$id: csproj <AssemblyVersion> missing or malformed: '${raw:-<none>}'"
+  if ! ver=$(resolved_version "$csproj"); then
+    err "$id: csproj <AssemblyVersion> missing or malformed (${csproj#"$ROOT"/})"
     return 1
   fi
-  ver=$(normalize3 "$raw")
 
   # Primary: tag/version match at release time.
   if [[ -n "${TAG_VERSION:-}" ]]; then
@@ -235,6 +248,19 @@ self_test() {
   _name() { printf '<info>\n  <name>%s</name>\n</info>\n' "$1" > "$2"; }
   # Read back the <name> text from an Info.xml fixture file.
   _read() { perl -CSD -ne 'if (m{<name>(.*)</name>}) { print $1; exit }' "$1"; }
+  # Write a minimal csproj whose <AssemblyVersion> is $1 (omit/empty for none) to $2.
+  _csproj() {
+    if [[ -n "$1" ]]; then
+      printf '<Project><PropertyGroup><AssemblyVersion>%s</AssemblyVersion></PropertyGroup></Project>\n' "$1" > "$2"
+    else
+      printf '<Project><PropertyGroup></PropertyGroup></Project>\n' > "$2"
+    fi
+  }
+  # Assert that running $2... exits nonzero, tallying a pass or fail.
+  _expect_fail() { # desc, cmd...
+    if "${@:2}" >/dev/null 2>&1; then err "test: $1 -- unexpectedly succeeded"; fail=$((fail + 1));
+    else ok "test: $1"; pass=$((pass + 1)); fi
+  }
 
   # en with a space separator
   _name "Gift Alert Icon v1.0.2" "$tmp/en.xml"
@@ -268,6 +294,14 @@ self_test() {
   # normalize3
   _expect "normalize 2-part" "$(normalize3 "1.2")" "1.2.0"
   _expect "normalize 4-part" "$(normalize3 "15.0.0.0")" "15.0.0"
+
+  # resolved_version: valid -> normalized; missing/malformed -> nonzero (never 0.0.0).
+  _csproj "1.2" "$tmp/good.csproj"
+  _expect "resolved_version normalizes a valid version" "$(resolved_version "$tmp/good.csproj")" "1.2.0"
+  _csproj "" "$tmp/missing.csproj"
+  _expect_fail "resolved_version rejects a missing version" resolved_version "$tmp/missing.csproj"
+  _csproj "1.2.3.4.5" "$tmp/malformed.csproj"
+  _expect_fail "resolved_version rejects a malformed version" resolved_version "$tmp/malformed.csproj"
 
   echo
   if [[ "$fail" -gt 0 ]]; then

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -41,8 +41,11 @@ if [[ -t 1 ]]; then
 else
   C_OK=''; C_WARN=''; C_ERR=''; C_OFF=''
 fi
+# Print a success line (green when stdout is a TTY).
 ok()   { printf '%s[ ok ]%s   %s\n'   "$C_OK"   "$C_OFF" "$*"; }
+# Print a warning line (yellow when stdout is a TTY).
 warn() { printf '%s[warn]%s   %s\n'   "$C_WARN" "$C_OFF" "$*"; }
+# Print a failure line (red when stdout is a TTY).
 err()  { printf '%s[FAIL]%s   %s\n'   "$C_ERR"  "$C_OFF" "$*"; }
 
 # ---- version helpers ---------------------------------------------------------
@@ -61,6 +64,7 @@ normalize3() {
   printf '%s.%s.%s' "$a" "$b" "$c"
 }
 
+# True if $1 is a dotted version of 2-4 numeric components (e.g. 1.2 or 1.2.3.4).
 is_well_formed() { [[ "$1" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; }
 
 # Extract the trailing display version (the LAST "v<X.Y.Z>" before </name>).
@@ -106,6 +110,7 @@ mod_dir_for() {
 
 # ---- write -------------------------------------------------------------------
 
+# Sync one mod's Info.xml display suffixes to its csproj version; log each change.
 write_mod() {
   local id="$1" dir="$2" csproj raw ver f changed=0
   # shellcheck disable=SC2012
@@ -127,8 +132,8 @@ write_mod() {
 }
 
 # ---- check -------------------------------------------------------------------
-# Echoes nothing; returns the number of ERRORS for this mod (warnings excluded).
 
+# Echoes nothing; returns the number of ERRORS for this mod (warnings excluded).
 check_mod() {
   local id="$1" dir="$2" csproj raw ver errors=0 f lang disp
   # shellcheck disable=SC2012
@@ -181,6 +186,7 @@ check_mod() {
 
 # ---- mode dispatch -----------------------------------------------------------
 
+# Run "write" or "check" over one ModId or every mod ("all"); aggregate errors.
 run_over_target() {
   local action="$1" target="$2" id dir total_errors=0 count=0
   if [[ "$target" == "all" ]]; then
@@ -215,15 +221,19 @@ run_over_target() {
 
 # ---- self-tests --------------------------------------------------------------
 
+# Exercise the display-name regex against golden fixtures; return nonzero on fail.
 self_test() {
   local tmp pass=0 fail=0 rc=0
   tmp=$(mktemp -d)
 
+  # Assert actual ($2) equals expected ($3), tallying a pass or fail.
   _expect() { # desc, actual, expected
     if [[ "$2" == "$3" ]]; then ok "test: $1"; pass=$((pass + 1));
     else err "test: $1 -- got [$2] expected [$3]"; fail=$((fail + 1)); fi
   }
+  # Write an Info.xml fixture whose <name> is $1 to file $2.
   _name() { printf '<info>\n  <name>%s</name>\n</info>\n' "$1" > "$2"; }
+  # Read back the <name> text from an Info.xml fixture file.
   _read() { perl -CSD -ne 'if (m{<name>(.*)</name>}) { print $1; exit }' "$1"; }
 
   # en with a space separator
@@ -271,6 +281,7 @@ self_test() {
 
 # ---- entrypoint --------------------------------------------------------------
 
+# Print usage to stderr and exit 2.
 usage() {
   cat >&2 <<EOF
 Usage:
@@ -281,6 +292,7 @@ EOF
   exit 2
 }
 
+# Parse the mode flag and dispatch to --write, --check, or --test.
 main() {
   [[ $# -ge 1 ]] || usage
   case "$1" in

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -146,7 +146,7 @@ write_mod() {
       ok "$id: wrote v$ver -> ${f#"$ROOT"/}"
       changed=1
     fi
-  done < <(find "$dir/Info" -mindepth 2 -name 'Info.xml' 2>/dev/null | sort)
+  done < <(find "$dir/Info" -mindepth 2 -maxdepth 2 -name 'Info.xml' 2>/dev/null | sort)
   [[ "$changed" -eq 0 ]] && ok "$id: already in sync (v$ver)"
   return 0
 }
@@ -201,7 +201,7 @@ check_mod() {
     else
       warn "$id [$lang]: display v$disp != source of truth v$ver (translator-owned; not auto-fixed)"
     fi
-  done < <(find "$dir/Info" -mindepth 2 -name 'Info.xml' 2>/dev/null | sort)
+  done < <(find "$dir/Info" -mindepth 2 -maxdepth 2 -name 'Info.xml' 2>/dev/null | sort)
 
   return "$errors"
 }

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -67,15 +67,20 @@ normalize3() {
 # True if $1 is a dotted version of 2-4 numeric components (e.g. 1.2 or 1.2.3.4).
 is_well_formed() { [[ "$1" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; }
 
-# Resolve a csproj's <AssemblyVersion> to a normalized X.Y.Z, echoed to stdout.
-# Returns nonzero and echoes nothing when the version is missing or malformed.
-# This is the single chokepoint so the checker, the writer, and the packager
-# all agree on what a valid version is and none silently turns a bad one into
-# "0.0.0"; callers report the failure (with the offending csproj path).
+# Normalize a raw version STRING to X.Y.Z, echoed to stdout; nonzero (and echoes
+# nothing) when it is missing or malformed. The single validate-then-normalize
+# chokepoint: no caller feeds normalize3 unchecked input (which would silently
+# fabricate values like 0.0.0 or abc.0.0). Guards both the csproj source of
+# truth and the release tag. Callers report the failure.
+normalized_or_fail() {
+  is_well_formed "$1" || return 1
+  normalize3 "$1"
+}
+
+# Resolve a csproj's <AssemblyVersion> to a normalized X.Y.Z (nonzero if missing
+# or malformed) — the file-reading wrapper over normalized_or_fail.
 resolved_version() {
-  local raw; raw=$(csproj_version_raw "$1")
-  is_well_formed "$raw" || return 1
-  normalize3 "$raw"
+  normalized_or_fail "$(csproj_version_raw "$1")"
 }
 
 # Extract the trailing display version (the LAST "v<X.Y.Z>" before </name>).
@@ -150,7 +155,7 @@ write_mod() {
 
 # Echoes nothing; returns the number of ERRORS for this mod (warnings excluded).
 check_mod() {
-  local id="$1" dir="$2" csproj ver errors=0 f lang disp
+  local id="$1" dir="$2" csproj ver tagver errors=0 f lang disp
   # shellcheck disable=SC2012
   csproj=$(ls "$dir"/*.csproj | head -1)
 
@@ -160,14 +165,18 @@ check_mod() {
     return 1
   fi
 
-  # Primary: tag/version match at release time.
+  # Primary: tag/version match at release time. Validate before normalizing so a
+  # malformed tag (e.g. a stray "v" prefix) fails loudly instead of being coerced
+  # into a bogus value that the comparison then silently mis-judges.
   if [[ -n "${TAG_VERSION:-}" ]]; then
-    local tagver; tagver=$(normalize3 "$TAG_VERSION")
-    if [[ "$ver" != "$tagver" ]]; then
+    if ! tagver=$(normalized_or_fail "$TAG_VERSION"); then
+      err "$id: tag version '$TAG_VERSION' is malformed (expected X.Y.Z)"
+      errors=$((errors + 1))
+    elif [[ "$ver" == "$tagver" ]]; then
+      ok "$id: tag v$tagver == csproj v$ver"
+    else
       err "$id: tag version v$tagver != csproj <AssemblyVersion> v$ver"
       errors=$((errors + 1))
-    else
-      ok "$id: tag v$tagver == csproj v$ver"
     fi
   fi
 
@@ -302,6 +311,11 @@ self_test() {
   _expect_fail "resolved_version rejects a missing version" resolved_version "$tmp/missing.csproj"
   _csproj "1.2.3.4.5" "$tmp/malformed.csproj"
   _expect_fail "resolved_version rejects a malformed version" resolved_version "$tmp/malformed.csproj"
+
+  # normalized_or_fail: the validate-then-normalize chokepoint (also guards TAG_VERSION).
+  _expect "normalized_or_fail normalizes a valid string" "$(normalized_or_fail "1.2")" "1.2.0"
+  _expect_fail "normalized_or_fail rejects a v-prefixed string" normalized_or_fail "v1.0.0"
+  _expect_fail "normalized_or_fail rejects an empty string" normalized_or_fail ""
 
   echo
   if [[ "$fail" -gt 0 ]]; then

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -291,4 +291,9 @@ main() {
   esac
 }
 
-main "$@"
+# Run only when executed directly; allow `source`-ing as a library (this lets
+# scripts/package-mods.sh reuse discover_mods + the version helpers, so the
+# packager and the drift gate always agree on what a mod is).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -174,7 +174,7 @@ check_mod() {
     if [[ "$disp" == "$ver" ]]; then
       ok "$id [$lang]: display v$disp matches"
     elif [[ "$lang" == "en" ]]; then
-      err "$id [en]: display v$disp != source of truth v$ver (run: $0 --write $id)"
+      err "$id [en]: display v$disp != source of truth v$ver (run: scripts/check-versions.sh --write $id)"
       errors=$((errors + 1))
     else
       warn "$id [$lang]: display v$disp != source of truth v$ver (translator-owned; not auto-fixed)"

--- a/scripts/package-mods.sh
+++ b/scripts/package-mods.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# package-mods.sh — build every mod in Release and produce the release zips.
+#
+# Reuses mod discovery + version helpers from check-versions.sh (sourced as a
+# library), so the packager and the drift gate always agree on what a mod is.
+#
+# Usage:
+#   scripts/package-mods.sh <output-dir>
+#
+# Produces in <output-dir>:
+#   <ModId>.zip      one per mod; the single top-level folder is <ModId>/
+#   all-mods.zip     every mod together (each under its own <ModId>/ folder)
+#   versions.json    { "ModId": "X.Y.Z", ... } — a recomputable manifest
+#
+# Each mod's build output is its bin/net35/ directory (OutputPath=bin\, the SDK
+# appends the TFM; configuration is NOT in the path, so a clean build is done to
+# avoid stale Debug output). That directory is zipped verbatim — it is exactly
+# the install payload for <game>/LobotomyCorp_Data/BaseMods/<ModId>/.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/check-versions.sh
+source "$HERE/check-versions.sh"   # discover_mods, csproj_version_raw, normalize3
+
+package_main() {
+  local out="${1:-}"
+  [[ -n "$out" ]] || { echo "usage: $0 <output-dir>" >&2; exit 2; }
+  mkdir -p "$out"; out="$(cd "$out" && pwd)"
+
+  local stage; stage="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$stage'" EXIT
+
+  local id dir csproj ver count=0
+  local manifest_lines="$stage/.versions.tsv"
+  : > "$manifest_lines"
+
+  while IFS=$'\t' read -r id dir; do
+    # shellcheck disable=SC2012  # mod csproj names are controlled; ls is fine
+    csproj=$(ls "$dir"/*.csproj | head -1)
+    ver=$(normalize3 "$(csproj_version_raw "$csproj")")
+    echo ">> building $id (v$ver) -c Release"
+    rm -rf "${dir:?}/bin" "${dir:?}/obj"
+    dotnet build "$csproj" -c Release --nologo -v minimal
+    mkdir -p "$stage/$id"
+    cp -R "$dir/bin/net35/." "$stage/$id/"
+    ( cd "$stage" && zip -qr "$out/$id.zip" "$id" )
+    printf '%s\t%s\n' "$id" "$ver" >> "$manifest_lines"
+    count=$((count + 1))
+    echo "   packaged $out/$id.zip"
+  done < <(discover_mods)
+
+  [[ "$count" -gt 0 ]] || { echo "error: no mods discovered" >&2; exit 1; }
+
+  ( cd "$stage" && zip -qr "$out/all-mods.zip" . -x '.versions.tsv' )
+  echo "   packaged $out/all-mods.zip ($count mods)"
+
+  # versions.json — recomputable manifest, built from the same data.
+  jq -Rn '[inputs | split("\t") | {key: .[0], value: .[1]}] | from_entries' \
+    < "$manifest_lines" > "$out/versions.json"
+  echo "   wrote $out/versions.json"
+
+  echo "done: $count mods -> $out"
+}
+
+package_main "$@"

--- a/scripts/package-mods.sh
+++ b/scripts/package-mods.sh
@@ -33,7 +33,7 @@ package_main() {
   mkdir -p "$out"; out="$(cd "$out" && pwd)"
 
   local stage; stage="$(mktemp -d)"
-  # shellcheck disable=SC2064
+  # shellcheck disable=SC2064  # expand $stage now so the trap removes this exact temp dir
   trap "rm -rf '$stage'" EXIT
 
   local id dir csproj ver count=0

--- a/scripts/package-mods.sh
+++ b/scripts/package-mods.sh
@@ -25,6 +25,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/check-versions.sh
 source "$HERE/check-versions.sh"   # discover_mods, csproj_version_raw, normalize3
 
+# Build every discovered mod in Release and emit per-mod zips, all-mods.zip, and
+# versions.json into <output-dir> (the sole positional argument).
 package_main() {
   local out="${1:-}"
   [[ -n "$out" ]] || { echo "usage: $0 <output-dir>" >&2; exit 2; }

--- a/scripts/package-mods.sh
+++ b/scripts/package-mods.sh
@@ -52,6 +52,12 @@ package_main() {
     echo ">> building $id (v$ver) -c Release"
     rm -rf "${dir:?}/bin" "${dir:?}/obj"
     dotnet build "$csproj" -c Release --nologo -v minimal
+    # The build can succeed without producing the expected net35 output (e.g. a
+    # retargeted TFM); fail with a clear message instead of a cryptic cp error.
+    if [[ ! -d "$dir/bin/net35" ]]; then
+      echo "error: $id build succeeded but produced no bin/net35 output" >&2
+      exit 1
+    fi
     mkdir -p "$stage/$id"
     cp -R "$dir/bin/net35/." "$stage/$id/"
     ( cd "$stage" && zip -qr "$out/$id.zip" "$id" )

--- a/scripts/package-mods.sh
+++ b/scripts/package-mods.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/check-versions.sh
-source "$HERE/check-versions.sh"   # discover_mods, csproj_version_raw, normalize3
+source "$HERE/check-versions.sh"   # discover_mods, resolved_version (+ helpers)
 
 # Build every discovered mod in Release and emit per-mod zips, all-mods.zip, and
 # versions.json into <output-dir> (the sole positional argument).
@@ -43,7 +43,12 @@ package_main() {
   while IFS=$'\t' read -r id dir; do
     # shellcheck disable=SC2012  # mod csproj names are controlled; ls is fine
     csproj=$(ls "$dir"/*.csproj | head -1)
-    ver=$(normalize3 "$(csproj_version_raw "$csproj")")
+    # Validate the source of truth before building or writing versions.json, so a
+    # missing/malformed <AssemblyVersion> fails loudly instead of shipping v0.0.0.
+    if ! ver=$(resolved_version "$csproj"); then
+      echo "error: $id has a missing or malformed <AssemblyVersion> (${csproj#"$ROOT"/})" >&2
+      exit 1
+    fi
     echo ">> building $id (v$ver) -c Release"
     rm -rf "${dir:?}/bin" "${dir:?}/obj"
     dotnet build "$csproj" -c Release --nologo -v minimal


### PR DESCRIPTION
## What

Adds reliable, per-mod release automation. To release one mod, push a tag
`<ModId>-v<X.Y.Z>` (e.g. `BugFixes-v3.0.2`): the workflow rebuilds the whole mod
set and publishes a dated aggregate **snapshot** release, **without touching any
other mod's release**.

## Phases (each independently shippable)

**Phase 0 — clean baseline**
- Synced GiftAlertIcon Chinese launcher name (`v1.0.1` → `v1.0.2`).
- Documented the WarnWhenDie versioning convention (major = number of
  abnormalities it warns about; confirmed 15 against the source).

**Phase 1 — version drift gate**
- `scripts/check-versions.sh`: csproj `<AssemblyVersion>` is the source of truth;
  syncs/verifies the `Info/{lang}/Info.xml` display suffixes. English hard-fails;
  other locales warn (translator-owned). Self-tests guard the regex.
- CI `version-check` job (no .NET/DLLs); the required `status` check depends on it.

**Phase 2 — release workflow + packaging**
- `scripts/package-mods.sh`: builds every mod `-c Release` → `<ModId>.zip` +
  `all-mods.zip` + `versions.json` (the `bin/net35/` output zipped verbatim — the
  exact `BaseMods` install payload). Reuses the gate's mod discovery so the two
  always agree on what a mod is.
- `.github/workflows/release-mod.yml`: **build** job (`contents: read`) validates
  allowlist + ancestor-of-`main` + version *before any secret*, then replicates
  the org CI private-DLL checkout and builds; **snapshot** job (`contents: write`)
  publishes `snapshot-<YYYY.MM.DD>` (CalVer) marked **Latest** with all zips +
  `versions.json` and a generated per-mod version table.
- README Download section.

**Phase 3a — docs + manual Nexus**
- `releasing/NEXUS_UPLOAD.md` per-mod manual checklist; rewrote the stale
  `DOCUMENTATION_UPDATING_CHECKLIST.md`; updated the committed agent instructions.

## Versioning

The aggregate snapshot version is **CalVer (the date)** — a monotonic ordering
marker, not a mod-count. Per-mod versions (zip names + notes table) are the real
signal. "Latest" is set by the `--latest` flag (not version-string sorting), so
dated snapshots cleanly supersede the old `v6.x` tags with no dual-scheme conflict.

## Mod count

Built **mod-agnostically**: `main` currently has 6 mods (DontChatMe lives on its
own unmerged branch). When that merges, it is picked up automatically — nothing
hardcodes the set or count.

## Deferred / out-of-band (not in this PR)

- **Phase 3b — Nexus auto-upload**: deferred until the official
  `Nexus-Mods/upload-action` input contract settles (>7 days old, no further
  breaking changes). Until then Nexus uploads are manual per `releasing/`.
- **Tag-protection ruleset** (admin): restrict `*-v*` tag creation. Applied
  out-of-band.
- **First real release** is the end-to-end test (forks can't run it — they lack
  the private-DLL/packages secrets), done as a controlled tag after merge.

## Verification (local)

- `check-versions.sh --test` + `--check all` pass; cn drift warns (exit 0), en
  drift and a wrong tag version fail (exit 1).
- All 6 mods build + package clean — verified **no `.pdb`, game/Unity DLL, or
  README** leaks into any artifact.
- Release-notes generation, both workflow YAMLs, `actionlint`, and `shellcheck`
  all pass.

https://claude.ai/code/session_018ropzL4kVmcfMKHDRk7Jcc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added an automated per-mod release pipeline that publishes snapshot and “latest” artifacts based on version tags.
  - Introduced CI “version drift” checks to ensure each mod’s version matches its in-game display names.

- **Documentation**
  - Expanded the README with a clear download/install section.
  - Replaced the old release checklist with a dedicated “Releasing a Mod” workflow, plus a Nexus upload checklist.
  - Updated versioning guidance, including the custom major-version convention for the warnings mod.

- **Chores**
  - Synced mod version/display information for updated releases (e.g., locale display name bump).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->